### PR TITLE
Link to in html

### DIFF
--- a/lib/hanami/helpers/html_helper/html_builder.rb
+++ b/lib/hanami/helpers/html_helper/html_builder.rb
@@ -289,6 +289,9 @@ module Hanami
         #
         # @return [self]
         #
+        # @since 0.1.0
+        # @api public
+        #
         # @see Hanami::Helpers::HtmlHelper
         # @see Hanami::Helpers::HtmlHelper::TextNode
         #
@@ -305,6 +308,56 @@ module Hanami
         #   # </label>
         def text(content)
           @nodes << TextNode.new(content)
+          self
+        end
+
+        # Returns self
+        #
+        # @return [self]
+        #
+        # @since x.x.x
+        # @api public
+        #
+        # @see Hanami::Helpers::HtmlHelper
+        # @see Hanami::Helpers::HtmlHelper::TextNode
+        #
+        # @example
+        #
+        #   html.label do
+        #     p 'hello'
+        #     html.span 'hanami'
+        #   end
+        #
+        #   # <label>
+        #   #   <p>hello</p>
+        #   #   <span>hanami</span>
+        #   # </label>
+        def html
+          self
+        end
+
+        # Alias for link_to helper
+        #
+        # @return [self]
+        #
+        # @since x.x.x
+        # @api public
+        #
+        # @see Hanami::Helpers::LinkToHelper
+        #
+        # @example
+        #
+        #   html.label do
+        #     p 'hello'
+        #     link_to('Posts', 'posts')
+        #   end
+        #
+        #   # <label>
+        #   #   <p>hello</p>
+        #   #   <a href=\"posts\">Posts</a>
+        #   # </label>
+        def link_to(content, url = nil, options = {}, &blk)
+          link_to_builder(content, url, options, &blk)
           self
         end
 
@@ -344,6 +397,29 @@ module Hanami
         # @api private
         def nested?
           @nodes.any?
+        end
+
+        # Simple builder helper with returns HtmlBuilder
+        # instance with a tag.
+        #
+        # @return [self] the result of the check
+        #
+        # @since x.x.x
+        # @api private
+        def link_to_builder(content, url, options, &blk)
+          if block_given?
+            options = url || {}
+            url     = content
+            content = nil
+          end
+
+          begin
+            options[:href] = url or raise ArgumentError
+          rescue TypeError
+            raise ArgumentError
+          end
+
+          a(blk || content, options)
         end
 
         # Resolve the context for nested contents

--- a/lib/hanami/helpers/link_to_helper.rb
+++ b/lib/hanami/helpers/link_to_helper.rb
@@ -116,19 +116,7 @@ module Hanami
       #   <%= link_to 'Home' %>
       #     # => ArgumentError
       def link_to(content, url = nil, options = {}, &blk)
-        if block_given?
-          options = url || {}
-          url     = content
-          content = nil
-        end
-
-        begin
-          options[:href] = url or raise ArgumentError
-        rescue TypeError
-          raise ArgumentError
-        end
-
-        html.a(blk || content, options).to_s
+        html.link_to_builder(content, url, options, &blk).to_s
       end
     end
   end

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -570,7 +570,7 @@ class LinkTo
 
 end
 
-class HtmlAndLinkTo
+class HtmlAndHtml
   include Hanami::Helpers::HtmlHelper
   include Hanami::Helpers::LinkToHelper
 
@@ -585,6 +585,13 @@ class HtmlAndLinkTo
     html.div do
       span 'hello'
       link_to('Comments', 'comments')
+    end
+  end
+
+  def two_spans_in_div
+    html.div do
+      span 'hello'
+      html.span 'world'
     end
   end
 end

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -569,3 +569,22 @@ class LinkTo
   end
 
 end
+
+class HtmlAndLinkTo
+  include Hanami::Helpers::HtmlHelper
+  include Hanami::Helpers::LinkToHelper
+
+  def two_links_to_in_div
+    html.div do
+      link_to('Posts', 'posts')
+      link_to('Comments', 'comments')
+    end
+  end
+
+  def span_and_link_to_in_div
+    html.div do
+      span 'hello'
+      link_to('Comments', 'comments')
+    end
+  end
+end

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -576,15 +576,15 @@ class HtmlAndHtml
 
   def two_links_to_in_div
     html.div do
-      link_to('Posts', 'posts')
       link_to('Comments', 'comments')
+      link_to('Posts', 'posts')
     end
   end
 
   def span_and_link_to_in_div
     html.div do
       span 'hello'
-      link_to('Comments', 'comments')
+      link_to('Posts', 'posts')
     end
   end
 

--- a/test/html_helper_test.rb
+++ b/test/html_helper_test.rb
@@ -95,7 +95,7 @@ describe Hanami::Helpers::HtmlHelper do
 
   describe 'with link_to helper' do
     before do
-      @view = HtmlAndLinkTo.new
+      @view = HtmlAndHtml.new
     end
 
     it 'returns two links in div' do
@@ -104,6 +104,10 @@ describe Hanami::Helpers::HtmlHelper do
 
     it 'returns span and link in div' do
       @view.span_and_link_to_in_div.to_s.must_equal %(<div>\n<span>hello</span>\n<a href=\"posts\">Posts</a>\n</div>)
+    end
+
+    it 'returns two spans in div' do
+      @view.two_spans_in_div.to_s.must_equal %(<div>\n<span>hello</span>\n<span>world</span>\n</div>)
     end
   end
 end

--- a/test/html_helper_test.rb
+++ b/test/html_helper_test.rb
@@ -92,4 +92,18 @@ describe Hanami::Helpers::HtmlHelper do
   it 'autoescapes nested blocks' do
     @view.evil_nested_block_content.to_s.must_equal %(<div>\n<p>&lt;script&gt;alert(&apos;xss&apos;)&lt;&#x2F;script&gt;</p>\n</div>)
   end
+
+  describe 'with link_to helper' do
+    before do
+      @view = HtmlAndLinkTo.new
+    end
+
+    it 'returns two links in div' do
+      @view.two_links_to_in_div.to_s.must_equal %(<div>\n<a href=\"comments\">Comments</a>\n<a href=\"posts\">Posts</a>\n</div>)
+    end
+
+    it 'returns span and link in div' do
+      @view.span_and_link_to_in_div.to_s.must_equal %(<div>\n<span>hello</span>\n<a href=\"posts\">Posts</a>\n</div>)
+    end
+  end
 end


### PR DESCRIPTION
Fixed #48
Also I fixed case when `html` helper called inside another `html` helper. For example:
``` ruby
html.div do
  span 'hello'
  html.div { span 'hanami' }
end
```

/cc @hanami/core-team 