### PR TITLE
adding datalist form helper

### DIFF
--- a/lib/hanami/helpers/form_helper/form_builder.rb
+++ b/lib/hanami/helpers/form_helper/form_builder.rb
@@ -766,6 +766,45 @@ module Hanami
           end
         end
 
+        # Datalist input
+        #
+        # @param name [Symbol] the input name
+        # @param values [Hash] a Hash to generate <tt><option></tt> tags of datalist.
+        #   Keys correspond to <tt>value</tt> and values correspond to the content.
+        # @param list [String] the name of list for the text input, it's also the id of datalist
+        # @param attributes [Hash] HTML attributes to pass to the input tag
+        #
+        # @since 0.3.1
+        #
+        # @example Basic usage
+        #   <%=
+        #     # ...
+        #     values = Hash['it' => 'Italy', 'us' => 'United States']
+        #     datalist :stores, values, 'books'
+        #   %>
+        #
+        #   # Output:
+        #   #  <input type="text" name="book[store]" id="book-store" list="books">
+        #   #  <datalist id="books">
+        #   #    <option value="Italy"></option>
+        #   #    <option value="United States"></option>
+        #   #  </datalist>
+        def datalist(name, values, list, attributes = {})
+          options  = attributes.delete(:options) || {}
+          datalist = attributes.delete(:datalist) || {}
+          attributes = { type: 'text', name: _input_name(name), id: _input_id(name), list: list }.merge(attributes)
+
+          # remove 'id' attribute
+          datalist = { id: list }.merge(datalist)
+
+          input(attributes)
+          super(datalist) do
+            values.each do |value, content|
+              option(value, {value: content}.merge(options))
+            end
+          end
+        end
+
         # Submit button
         #
         # @param content [String] The content

--- a/test/form_helper_test.rb
+++ b/test/form_helper_test.rb
@@ -1188,4 +1188,56 @@ describe Hanami::Helpers::FormHelper do
       end
     end
   end
+
+  describe "#datalist" do
+    let(:values) { Hash['it' => 'Italy', 'us' => 'United States'] }
+
+    it "renders" do
+      actual = view.form_for(:book, action) do
+        datalist :store, values, 'books'
+      end.to_s
+
+      actual.must_include %(<input type="text" name="book[store]" id="book-store" list="books">\n<datalist id="books">\n<option value="Italy">it</option>\n<option value="United States">us</option>\n</datalist>)
+    end
+
+    it "just allows to override 'id' attribute of the text input" do
+      actual = view.form_for(:book, action) do
+        datalist :store, values, 'books', id: 'store'
+      end.to_s
+
+      actual.must_include %(<input type="text" name="book[store]" id="store" list="books">\n<datalist id="books">\n<option value="Italy">it</option>\n<option value="United States">us</option>\n</datalist>)
+    end
+
+    it "allows to override 'name' attribute" do
+      actual = view.form_for(:book, action) do
+        datalist :store, values, 'books', name: 'store'
+      end.to_s
+
+      actual.must_include %(<input type="text" name="store" id="book-store" list="books">\n<datalist id="books">\n<option value="Italy">it</option>\n<option value="United States">us</option>\n</datalist>)
+    end
+
+    it "allows to specify HTML attributes" do
+      actual = view.form_for(:book, action) do
+        datalist :store, values, 'books', class: 'form-control'
+      end.to_s
+
+      actual.must_include %(<input type="text" name="book[store]" id="book-store" list="books" class="form-control">\n<datalist id="books">\n<option value="Italy">it</option>\n<option value="United States">us</option>\n</datalist>)
+    end
+
+    it "allows to specify HTML attributes for options" do
+      actual = view.form_for(:book, action) do
+        datalist :store, values, 'books', options: { class: 'form-option' }
+      end.to_s
+
+      actual.must_include %(<input type="text" name="book[store]" id="book-store" list="books">\n<datalist id="books">\n<option value="Italy" class="form-option">it</option>\n<option value="United States" class="form-option">us</option>\n</datalist>)
+    end
+
+    it "allows to specify HTML attributes for datalist" do
+      actual = view.form_for(:book, action) do
+        datalist :store, values, 'books', datalist: { class: 'form-option' }
+      end.to_s
+
+      actual.must_include %(<input type="text" name="book[store]" id="book-store" list="books">\n<datalist id="books" class="form-option">\n<option value="Italy">it</option>\n<option value="United States">us</option>\n</datalist>)
+    end
+  end
 end


### PR DESCRIPTION
Adding `datalist` form helper, fix #57 

- [x] Basic render

    ```html
   <input list="browsers" name="browser">
  <datalist id="browsers">
    <option value="Internet Explorer">
    <option value="Firefox">
    <option value="Chrome">
    <option value="Opera">
    <option value="Safari">
  </datalist>
    ```
- [x] Just allows to override 'id' attribute of the text input
- [x] Allows to override 'name' attribute of the text input
- [x] Allows to specify HTML attributes of the text input
- [x] Allows to specify HTML attributes for datalist
- [x] Allows to specify HTML attributes for options

The only problem I think we need to fix is about `option` tag, it's `CONTENT_TAGS` on `html_builder.rb` so that it will have close tag.

This is my first pull request for Ruby/Hanami (I just learned Ruby about 3 months ago and didn't work much with it). Please let me know if there's anything wrong.

Thank you.

P/S: sorry for my bad English.