### PR TITLE
Invert values for form builder's select

### DIFF
--- a/lib/hanami/helpers/form_helper/form_builder.rb
+++ b/lib/hanami/helpers/form_helper/form_builder.rb
@@ -711,7 +711,7 @@ module Hanami
         #
         # @param name [Symbol] the input name
         # @param values [Hash] a Hash to generate <tt><option></tt> tags.
-        #   Keys correspond to <tt>value</tt> and values correspond to the content.
+        #   Values correspond to <tt>value</tt> and keys correspond to the content.
         # @param attributes [Hash] HTML attributes to pass to the input tag
         #
         # If request params have a value that corresponds to one of the given values,
@@ -723,7 +723,7 @@ module Hanami
         # @example Basic usage
         #   <%=
         #     # ...
-        #     values = Hash['it' => 'Italy', 'us' => 'United States']
+        #     values = Hash['Italy' => 'it', 'United States' => 'us']
         #     select :stores, values
         #   %>
         #
@@ -756,7 +756,7 @@ module Hanami
           attributes = { name: _input_name(name), id: _input_id(name) }.merge(attributes)
 
           super(attributes) do
-            values.each do |value, content|
+            values.each do |content, value|
               if _value(name) == value
                 option(content, {value: value, selected: SELECTED}.merge(options))
               else

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -3,6 +3,12 @@ require 'hanami/controller'
 require 'hanami/helpers/html_helper'
 require 'hanami/helpers/escape_helper'
 
+Store = Struct.new(:code, :label) do
+  def to_ary
+    [label, code]
+  end
+end
+
 class HtmlView
   include Hanami::Helpers::HtmlHelper
 

--- a/test/form_helper_test.rb
+++ b/test/form_helper_test.rb
@@ -1133,7 +1133,7 @@ describe Hanami::Helpers::FormHelper do
   end
 
   describe "#select" do
-    let(:values) { Hash['it' => 'Italy', 'us' => 'United States'] }
+    let(:values) { Hash['Italy' => 'it', 'United States' => 'us'] }
 
     it "renders" do
       actual = view.form_for(:book, action) do

--- a/test/form_helper_test.rb
+++ b/test/form_helper_test.rb
@@ -1175,6 +1175,56 @@ describe Hanami::Helpers::FormHelper do
       actual.must_include %(<select name="book[store]" id="book-store">\n<option value="it" class="form-option">Italy</option>\n<option value="us" class="form-option">United States</option>\n</select>)
     end
 
+    describe "with values an structured Array of values" do
+      let(:values) { [['Italy', 'it'], ['United States', 'us']] }
+
+      it "renders" do
+        actual = view.form_for(:book, action) do
+          select :store, values
+        end.to_s
+
+        actual.must_include %(<select name="book[store]" id="book-store">\n<option value="it">Italy</option>\n<option value="us">United States</option>\n</select>)
+      end
+
+      describe "and filled params" do
+        let(:params) { Hash[book: { store: val }] }
+        let(:val)    { 'it' }
+
+        it "renders with value" do
+          actual = view.form_for(:book, action) do
+            select :store, values
+          end.to_s
+
+          actual.must_include %(<select name="book[store]" id="book-store">\n<option value="it" selected="selected">Italy</option>\n<option value="us">United States</option>\n</select>)
+        end
+      end
+    end
+
+    describe "with values an Array of objects" do
+      let(:values) { [Store.new('it', 'Italy'), Store.new('us', 'United States')] }
+
+      it "renders" do
+        actual = view.form_for(:book, action) do
+          select :store, values
+        end.to_s
+
+        actual.must_include %(<select name="book[store]" id="book-store">\n<option value="it">Italy</option>\n<option value="us">United States</option>\n</select>)
+      end
+
+      describe "and filled params" do
+        let(:params) { Hash[book: { store: val }] }
+        let(:val)    { 'it' }
+
+        it "renders with value" do
+          actual = view.form_for(:book, action) do
+            select :store, values
+          end.to_s
+
+          actual.must_include %(<select name="book[store]" id="book-store">\n<option value="it" selected="selected">Italy</option>\n<option value="us">United States</option>\n</select>)
+        end
+      end
+    end
+
     describe "with filled params" do
       let(:params) { Hash[book: { store: val }] }
       let(:val)    { 'it' }


### PR DESCRIPTION
**This is a breaking change proposal. If approved, we have to bump the minor version to `v0.4.0`.**

---

## Actual

The `values` has must to be composed with: keys as `value` attribute and values as content of the `<option>` tag.

### Example

```erb
<%=
  values = Hash['it' => 'Italy', 'us' => 'United States']
  select :stores, values
%>
```

```html
<select name="book[store]" id="book-store">
  <option value="it">Italy</option>
  <option value="us">United States</option>
</select>
```

## Proposed

The `values` has must to be composed with: values as `value` attribute and keys as content of the `<option>` tag.

### Example

```erb
<%=
  values = Hash['Italy' => 'it', 'United States' => 'us']
  select :stores, values
%>
```

```html
<select name="book[store]" id="book-store">
  <option value="it">Italy</option>
  <option value="us">United States</option>
</select>
```

### Reasons

There are a few reasons:

  * Better "sortable" experience. Sorting a Hash by key, is easier than by value. Ref https://github.com/hanami/helpers/issues/59
  * We had to implement `datalist` helper by using this new "inverted" syntax. Ref https://github.com/hanami/helpers/pull/60 and https://github.com/hanami/helpers/commit/4a885a6699892ac78b74ad08f7cc04b9b89bc4dd
  * It's consistent across Ruby ecosystem: Rails and Padrino this "inverted" syntax. This avoids the mental overhead of switching between frameworks

---

/cc @hanami/core-team @hanami/contributors 