### PR TITLE
Explicitly require some hanami-utils dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ View helpers for Ruby web applications
 ### Changed
 – [Luca Guidi] Drop support for Ruby 2.0 and 2.1
 
+### Fixed
+– [Nikolay Shebanov] Explicitly require some `hanami-utils` dependencies
+
 ## v0.3.0 - 2016-01-22
 ### Changed
 - [Luca Guidi] Renamed the project

--- a/lib/hanami/helpers/html_helper/html_fragment.rb
+++ b/lib/hanami/helpers/html_helper/html_fragment.rb
@@ -1,3 +1,5 @@
+require 'hanami/utils/escape'
+
 module Hanami
   module Helpers
     module HtmlHelper

--- a/lib/hanami/helpers/html_helper/html_node.rb
+++ b/lib/hanami/helpers/html_helper/html_node.rb
@@ -1,4 +1,5 @@
 require 'hanami/helpers/html_helper/empty_html_node'
+require 'hanami/utils/escape'
 
 module Hanami
   module Helpers

--- a/lib/hanami/helpers/html_helper/text_node.rb
+++ b/lib/hanami/helpers/html_helper/text_node.rb
@@ -1,3 +1,5 @@
+require 'hanami/utils/escape'
+
 module Hanami
   module Helpers
     module HtmlHelper

--- a/lib/hanami/helpers/number_formatting_helper.rb
+++ b/lib/hanami/helpers/number_formatting_helper.rb
@@ -1,3 +1,5 @@
+require 'hanami/utils/kernel'
+
 module Hanami
   module Helpers
     # Number formatter

--- a/lib/hanami/helpers/routing_helper.rb
+++ b/lib/hanami/helpers/routing_helper.rb
@@ -1,3 +1,5 @@
+require 'hanami/utils/string'
+
 module Hanami
   module Helpers
     # Routing helper for full stack Hanami web applications.


### PR DESCRIPTION
Thank you for such an awesome tool. I'm using `hanami-helpers` within a `middleman` project, and occasionally ran into dependency issues with some of the helpers. 