### PR TITLE
new dry-v syntax **DO NOT MERGE**

### DIFF
--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -339,10 +339,12 @@ class Delivery
 end
 
 class DeliveryParams < Hanami::Action::Params
-  param :delivery do
-    param :customer_id, type: Integer, presence: true
-    param :address do
-      param :street, type: String, presence: true
+  params do 
+    required(:delivery).schema do
+      required(:customer_id).filled(:int?)
+      required(:address).schema do
+        required(:street).filled(:str?)
+      end
     end
   end
 end


### PR DESCRIPTION
Still not working after new syntax... getting

```
undefined method `filled' for [:val, [:predicate, [:key?, [:_csrf_token]]]]:Dry::Validation::Schema::Rule (NoMethodError)
```
any ideas??

Gem versions after `bundle install`
```
Resolving dependencies...
Using rake 11.2.2
Using bundler 1.11.2
Using byebug 9.0.5
Using concurrent-ruby 1.0.2
Using json 1.8.3
Using docile 1.1.5
Using simplecov-html 0.10.0
Using tins 1.6.0
Using thor 0.19.1
Using dry-equalizer 0.2.0
Using dry-monads 0.0.1
Using inflecto 0.0.2
Using hanami-utils 0.8.0 from git://github.com/hanami/utils.git (at 0.8.x@8fcd94b)
Using rack 1.6.4
Using tilt 2.0.5
Using minitest 5.9.0
Using yard 0.8.7.6
Using dry-configurable 0.1.6
Using simplecov 0.11.2
Using term-ansicolor 1.3.2
Using hanami-helpers 0.4.0 from source at `.`
Using hanami-controller 0.7.0 from git://github.com/hanami/controller.git (at 0.7.x@0f3a22b)
Using hanami-view 0.7.0 from git://github.com/hanami/view.git (at 0.7.x@6a51e5c)
Using dry-container 0.3.4
Using coveralls 0.8.13
Using dry-logic 0.2.3
Using dry-types 0.7.2
Using dry-validation 0.7.4
Using hanami-validations 0.6.0 from git://github.com/hanami/validations.git (at 0.6.x@a448067)
```