### PR TITLE
Set selected option based on entity's attribute

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,6 @@ require 'bundler/gem_tasks'
 Rake::TestTask.new do |t|
   t.pattern = 'test/**/*_test.rb'
   t.libs.push 'test'
-  t.warning = false
 end
 
 namespace :test do

--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,7 @@ require 'bundler/gem_tasks'
 Rake::TestTask.new do |t|
   t.pattern = 'test/**/*_test.rb'
   t.libs.push 'test'
+  t.warning = false
 end
 
 namespace :test do
@@ -15,4 +16,3 @@ namespace :test do
 end
 
 task default: :test
-

--- a/lib/hanami/helpers/form_helper/form_builder.rb
+++ b/lib/hanami/helpers/form_helper/form_builder.rb
@@ -771,12 +771,15 @@ module Hanami
           options    = attributes.delete(:options) { {} }
           attributes = { name: _input_name(name), id: _input_id(name) }.merge(attributes)
           prompt     = options.delete(:prompt)
+          selected   = options.delete(:selected)
 
           super(attributes) do
             option(prompt) unless prompt.nil?
 
             values.each do |content, value|
-              if _value(name) == value
+              if selected == value
+                option(content, {value: value, selected: SELECTED}.merge(options))
+              elsif _value(name) == value
                 option(content, {value: value, selected: SELECTED}.merge(options))
               else
                 option(content, {value: value}.merge(options))

--- a/lib/hanami/helpers/form_helper/form_builder.rb
+++ b/lib/hanami/helpers/form_helper/form_builder.rb
@@ -767,6 +767,19 @@ module Hanami
         #   #    <option value="it">Italy</option>
         #   #    <option value="us">United States</option>
         #   #  </select>
+        #
+        # @example Selected option
+        #   <%=
+        #     # ...
+        #     values = Hash['it' => 'Italy', 'us' => 'United States']
+        #     select :stores, values, options: {selected: book.store}
+        #   %>
+        #
+        #   # Output:
+        #   #  <select name="book[store]" id="book-store">
+        #   #    <option value="it" selected="selected">Italy</option>
+        #   #    <option value="us">United States</option>
+        #   #  </select>
         def select(name, values, attributes = {})
           options    = attributes.delete(:options) { {} }
           attributes = { name: _input_name(name), id: _input_id(name) }.merge(attributes)
@@ -777,9 +790,7 @@ module Hanami
             option(prompt) unless prompt.nil?
 
             values.each do |content, value|
-              if selected == value
-                option(content, {value: value, selected: SELECTED}.merge(options))
-              elsif _value(name) == value
+              if selected == value || _value(name) == value
                 option(content, {value: value, selected: SELECTED}.merge(options))
               else
                 option(content, {value: value}.merge(options))

--- a/test/form_helper_test.rb
+++ b/test/form_helper_test.rb
@@ -1269,7 +1269,6 @@ describe Hanami::Helpers::FormHelper do
       end
     end
 
-    # add spec here
     describe "with selected attribute" do
       let(:params) { Hash[book: { store: val }] }
       let(:val)    { 'it' }
@@ -1280,7 +1279,6 @@ describe Hanami::Helpers::FormHelper do
         end.to_s
 
         actual.must_include %(<select name="book[store]" id="book-store">\n<option value="it" selected="selected">Italy</option>\n<option value="us">United States</option>\n</select>)
-        puts actual
       end
     end
   end

--- a/test/form_helper_test.rb
+++ b/test/form_helper_test.rb
@@ -1268,6 +1268,21 @@ describe Hanami::Helpers::FormHelper do
         end
       end
     end
+
+    # add spec here
+    describe "with selected attribute" do
+      let(:params) { Hash[book: { store: val }] }
+      let(:val)    { 'it' }
+
+      it "sets the selected attribute" do
+        actual = view.form_for(:book, action) do
+          select :store, values, options: { selected: val }
+        end.to_s
+
+        actual.must_include %(<select name="book[store]" id="book-store">\n<option value="it" selected="selected">Italy</option>\n<option value="us">United States</option>\n</select>)
+        puts actual
+      end
+    end
   end
 
   describe "#datalist" do


### PR DESCRIPTION
This is the implementation for https://github.com/hanami/helpers/issues/66.

It enables to set the selected option if one of the option values matches the passed entity's attribute:

`select :author, authors, selected: book.id`