### PR TITLE
Form values to support `Hash#dig`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,3 +2,5 @@ Metrics/LineLength:
   Enabled: false
 Style/AndOr:
   Enabled: false
+Style/MethodMissing:
+  Enabled: false

--- a/lib/hanami/helpers/form_helper/values.rb
+++ b/lib/hanami/helpers/form_helper/values.rb
@@ -67,7 +67,7 @@ module Hanami
         # @api private
         def _get_from_params(key)
           if @params.respond_to?(:dig)
-            @params.dig(*key.to_s.split(GET_SEPARATOR).map(&:to_sym))
+            @params.dig(*key.to_s.split(GET_SEPARATOR).map!(&:to_sym))
           else
             @params.get(key)
           end

--- a/lib/hanami/helpers/form_helper/values.rb
+++ b/lib/hanami/helpers/form_helper/values.rb
@@ -27,10 +27,51 @@ module Hanami
         # @since 0.2.0
         # @api private
         def get(key)
-          @params.get(key) || _get_from_values(key)
+          _get_from_params(key) || _get_from_values(key)
         end
 
         private
+
+        # Safely access nested values.
+        #
+        # <tt>Hanami::Action::Params</tt> already supports this feature with
+        # <tt>#get</tt>.
+        # But during testing phase it could happen to receive a <tt>Hash</tt>
+        # instead.
+        #
+        # For this purpose, we check if <tt>@params</tt> respond to
+        # <tt>#dig</tt>, which is a new Ruby 2.3 feature similar to
+        # <tt>Hanami::Action::Params#get</tt>.
+        # If the check is successful, we try to access the value with
+        # <tt>#dig</tt>, otherwise we assume that it responds to <tt>#get</tt>
+        # and use it.
+        #
+        # This implementation is safe to use, but it has several hidden perf costs:
+        #
+        #   * The runtime check for <tt>#respond_to?</tt>, which is inelegant too
+        #   * In case of <tt>#dig</tt> we need to transform a key like
+        #     <tt>:'order.customer.address.street'</tt> into
+        #     <tt>[:order, :customer, :address, :street]</tt>
+        #   * In case of <tt>#get</tt> its internal implementation isn't
+        #     efficient because it splits the key into an array and it uses
+        #     recursion to access nested values
+        #
+        # Because as of Ruby 2.3 we have <tt>Hash#dig</tt>, we should use it
+        # both in params and here, because it's faster (written in C).
+        # To make this possible, we should change the key notation from a dot
+        # separated string to an array of symbol.
+        #
+        # FIXME: Use Hash#dig when we'll support only Ruby 2.3+
+        #
+        # @since x.x.x
+        # @api private
+        def _get_from_params(key)
+          if @params.respond_to?(:dig)
+            @params.dig(*key.to_s.split(GET_SEPARATOR).map(&:to_sym))
+          else
+            @params.get(key)
+          end
+        end
 
         # @since 0.2.0
         # @api private

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -305,7 +305,21 @@ class FormHelperView
   attr_reader :params
 
   def initialize(params)
-    @params = Hanami::Action::BaseParams.new(params)
+    @params = _build_params(params)
+  end
+
+  private
+
+  def _build_params(params)
+    parameters = params.to_h
+
+    # Randomly use Hanami::Action::BaseParams or the given raw Hash in order to
+    # simulate Hash usage during the test setup unit tests in Hanami projects.
+    if parameters.respond_to?(:dig)
+      [true, false].sample ? Hanami::Action::BaseParams.new(parameters) : parameters
+    else
+      Hanami::Action::BaseParams.new(parameters)
+    end
   end
 end
 


### PR DESCRIPTION
This is useful to support unit tests setup in Hanami projects, when
developers wants to pass pure Hash to simulate params, instead of an
instance of `Hanami::Action::Params`.

Ref https://github.com/hanami/helpers/issues/71#issuecomment-239104711