### PR TITLE
New routes factory

### DIFF
--- a/lib/hanami/helpers/routing_helper.rb
+++ b/lib/hanami/helpers/routing_helper.rb
@@ -5,7 +5,7 @@ module Hanami
     # Routing helper for full stack Hanami web applications.
     #
     # For a given application called <tt>Web::Application</tt>, at runtime
-    # Hanami creates a routes factory called <tt>Web::Routes</tt>.
+    # Hanami creates a routes factory called <tt>Web.routes</tt>.
     #
     # By including this module in a view, it makes that factory avaliable as
     # <tt>routes</tt>.
@@ -41,7 +41,7 @@ module Hanami
     #   # <%= link_to_home %>
     module RoutingHelper
       def self.included(base)
-        factory = "#{Utils::String.new(base).namespace}::Routes"
+        factory = "#{Utils::String.new(base).namespace}.routes"
 
         base.class_eval <<-END_EVAL, __FILE__, __LINE__
           def routes

--- a/lib/hanami/helpers/version.rb
+++ b/lib/hanami/helpers/version.rb
@@ -3,6 +3,6 @@ module Hanami
     # Define version
     #
     # @since 0.1.0
-    VERSION = '0.4.0'.freeze
+    VERSION = '0.5.0'.freeze
   end
 end

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -375,25 +375,31 @@ end
 
 module FullStack
   class Routes
-    def self.path(name)
+    def path(name)
       _escape "/#{name}"
     end
 
-    def self.sessions_path
+    def sessions_path
       _escape '/sessions'
     end
 
-    def self.deliveries_path
+    def deliveries_path
       _escape '/deliveries'
     end
 
-    def self.delivery_path(attrs = {})
+    def delivery_path(attrs = {})
       _escape "/deliveries/#{attrs.fetch(:id)}"
     end
 
-    def self._escape(string)
+    private
+
+    def _escape(string)
       Hanami::Utils::Escape::SafeString.new(string)
     end
+  end
+
+  def self.routes
+    Routes.new
   end
 
   module Views

--- a/test/version_test.rb
+++ b/test/version_test.rb
@@ -2,6 +2,6 @@ require 'test_helper'
 
 describe Hanami::Helpers::VERSION do
   it 'exposes version' do
-    Hanami::Helpers::VERSION.must_equal '0.4.0'
+    Hanami::Helpers::VERSION.must_equal '0.5.0'
   end
 end


### PR DESCRIPTION
The next version of Hanami will expose application routes via `Web.routes` instead of `Web::Routes`.