### PR TITLE
Fix number formatting precision

### DIFF
--- a/lib/hanami/helpers/number_formatting_helper.rb
+++ b/lib/hanami/helpers/number_formatting_helper.rb
@@ -183,7 +183,7 @@ module Hanami
         def to_str
           number = to_number
           if precision_requested_explicity?
-            "%.#{precision}f" % number
+            Kernel.format("%.#{precision}f", number)
           else
             number.to_s
           end

--- a/lib/hanami/helpers/number_formatting_helper.rb
+++ b/lib/hanami/helpers/number_formatting_helper.rb
@@ -134,7 +134,7 @@ module Hanami
           @number = number
           @delimiter = options.fetch(:delimiter, DEFAULT_DELIMITER)
           @separator = options.fetch(:separator, DEFAULT_SEPARATOR)
-          @precision = options.fetch(:precision, DEFAULT_PRECISION)
+          @precision = options.fetch(:precision, nil)
         end
 
         # Format number according to the specified options
@@ -181,7 +181,12 @@ module Hanami
         # @since 0.2.0
         # @api private
         def to_str
-          to_number.to_s
+          number = to_number
+          if precision_requested_explicity?
+            "%.#{precision}f" % number
+          else
+            number.to_s
+          end
         end
 
         # Numeric coercion
@@ -203,6 +208,26 @@ module Hanami
           end
         end
 
+        # Returns precision with a fallback to default value
+        #
+        # @return [Numeric] precision
+        #
+        # @since 1.0.0
+        # @api private
+        def precision
+          @precision || DEFAULT_PRECISION
+        end
+
+        # Checks if precision was requested in options
+        #
+        # @return [TrueClass,FalseClass] the result of the check
+        #
+        # @since 1.0.0
+        # @api private
+        def precision_requested_explicity?
+          !@precision.nil?
+        end
+
         # Round number in case we need to return a <tt>Float</tt> representation.
         # If <tt>@number</tt> doesn't respond to <tt>#round</tt> return the number as it is.
         #
@@ -212,7 +237,7 @@ module Hanami
         # @api private
         def rounded_number
           if @number.respond_to?(:round)
-            @number.round(@precision)
+            @number.round(precision)
           else
             @number
           end

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -142,6 +142,14 @@ class NumbersView
     format_number 3.141592, precision: 4
   end
 
+  def precision_higher_than_numbers_precision
+    format_number 3.14, precision: 4
+  end
+
+  def zero_precision
+    format_number 3.14, precision: 0
+  end
+
   def mixed_digits
     format_number 5002.007, precision: 3
   end

--- a/test/number_formatting_helper_test.rb
+++ b/test/number_formatting_helper_test.rb
@@ -33,6 +33,14 @@ describe Hanami::Helpers::NumberFormattingHelper do
     @view.precision_format.must_equal '3.1416'
   end
 
+  it 'returns string padded with zeros' do
+    @view.precision_higher_than_numbers_precision.must_equal '3.1400'
+  end
+
+  it 'returns string with no decimal part' do
+    @view.zero_precision.must_equal '3'
+  end
+
   it 'returns string with "." delimiter and "," separator' do
     @view.euro_format.must_equal '1.234,12'
   end


### PR DESCRIPTION
This fixes https://github.com/hanami/helpers/issues/77

New method is only applied when precision is explicitly passed in options. It does not use default precision for that, because it would be backwards incompatible.

I didn't include solution for secon issue from #77, as I belier pull requests should be atomic. The issue was:

> One detail left: in case of an integer, user friendly use would be to have a default precision to 0, to avoid having format_number(1000) == "1,000.00" instead of "1,000"