### PR TITLE
Fix typo: explicity => explicitly

### DIFF
--- a/lib/hanami/helpers/number_formatting_helper.rb
+++ b/lib/hanami/helpers/number_formatting_helper.rb
@@ -182,7 +182,7 @@ module Hanami
         # @api private
         def to_str
           number = to_number
-          if precision_requested_explicity?
+          if precision_requested_explicitly?
             Kernel.format("%.#{precision}f", number)
           else
             number.to_s
@@ -224,7 +224,7 @@ module Hanami
         #
         # @since 1.0.0
         # @api private
-        def precision_requested_explicity?
+        def precision_requested_explicitly?
           !@precision.nil?
         end
 


### PR DESCRIPTION
> I have just noticed a shameful typo in my code, where method is named precision_requested_explicity? instead of precision_requested_explicitly?. 
> Can some maintainer fix it maybe, please? 😉

From https://github.com/hanami/helpers/pull/85#issuecomment-262731624

:)