### PR TITLE
Fix typo in select documentation

### DIFF
--- a/lib/hanami/helpers/form_helper/form_builder.rb
+++ b/lib/hanami/helpers/form_helper/form_builder.rb
@@ -726,7 +726,7 @@ module Hanami
         #   <%=
         #     # ...
         #     values = Hash['Italy' => 'it', 'United States' => 'us']
-        #     select :stores, values
+        #     select :store, values
         #   %>
         #
         #   # Output:
@@ -745,7 +745,7 @@ module Hanami
         #   <%=
         #     # ...
         #     values = Hash['it' => 'Italy', 'us' => 'United States']
-        #     select :stores, values
+        #     select :store, values
         #   %>
         #
         #   # Output:
@@ -758,7 +758,7 @@ module Hanami
         #   <%=
         #     # ...
         #     values = Hash['it' => 'Italy', 'us' => 'United States']
-        #     select :stores, values, options: {prompt: 'Select a store'}
+        #     select :store, values, options: {prompt: 'Select a store'}
         #   %>
         #
         #   # Output:
@@ -772,7 +772,7 @@ module Hanami
         #   <%=
         #     # ...
         #     values = Hash['it' => 'Italy', 'us' => 'United States']
-        #     select :stores, values, options: {selected: book.store}
+        #     select :store, values, options: {selected: book.store}
         #   %>
         #
         #   # Output:


### PR DESCRIPTION
You can see that in documentation we call `stores` instead `store`
http://www.rubydoc.info/gems/hanami-helpers/Hanami/Helpers/FormHelper/FormBuilder#select-instance_method

/cc @hanami/documentation 