### PR TITLE
properly handle nested field indexes

### DIFF
--- a/lib/hanami/helpers/form_helper/form_builder.rb
+++ b/lib/hanami/helpers/form_helper/form_builder.rb
@@ -233,8 +233,8 @@ module Hanami
         #   <form action="/deliveries" method="POST" accept-charset="utf-8" id="delivery-form">
         #     <input type="hidden" name="_csrf_token" value="920cd5bfaecc6e58368950e790f2f7b4e5561eeeab230aa1b7de1b1f40ea7d5d">
         #     <input type="text" name="delivery[customer_name]" id="delivery-customer-name" value="">
-        #     <input type="text" name="delivery[addresses][][street]" id="delivery-address-0-street" value="">
-        #     <input type="text" name="delivery[addresses][][street]" id="delivery-address-1-street" value="">
+        #     <input type="text" name="delivery[addresses][0][street]" id="delivery-address-0-street" value="">
+        #     <input type="text" name="delivery[addresses][1][street]" id="delivery-address-1-street" value="">
         #
         #     <button type="submit">Create</button>
         #   </form>
@@ -1444,7 +1444,7 @@ module Hanami
         # @api private
         # @since 0.2.0
         def _attributes(type, name, attributes)
-          attrs = { type: type, name: _displayed_input_name(name), id: _input_id(name), value: _value(name) }
+          attrs = { type: type, name: _input_name(name), id: _input_id(name), value: _value(name) }
           attrs.merge!(attributes)
           attrs[:value] = escape_html(attrs[:value])
           attrs

--- a/spec/integration/form_helper_spec.rb
+++ b/spec/integration/form_helper_spec.rb
@@ -91,8 +91,8 @@ RSpec.describe 'Form helper' do
   describe 'form with nested structures' do
     describe 'first page load' do
       before do
-        @address1 = Address.new(street: '5th Ave')
-        @address2 = Address.new(street: '4th Ave')
+        @address1 = Address.new(street: '5th Ave', city: 'New York')
+        @address2 = Address.new(street: '4th Ave', city: 'Seattle')
         @bill     = Bill.new(id: 1, addresses: [@address1, @address2])
         @params   = BillParams.new({})
         @session  = Session.new(_csrf_token: 's14')
@@ -101,14 +101,42 @@ RSpec.describe 'Form helper' do
       end
 
       it 'renders the form' do
-        expect(@actual).to include(%(<form action="/bills/#{@bill.id}" method="POST" accept-charset="utf-8" id="bill-form" class="form-horizontal">\n<input type="hidden" name="_method" value="PATCH">\n<input type="hidden" name="_csrf_token" value="#{@session[:_csrf_token]}">\n<fieldset>\n<legend>Addresses</legend>\n<div class="form-group">\n<label for="bill-addresses-0-street">Street</label>\n<input type="text" name="bill[addresses][][street]" id="bill-addresses-0-street" value="#{@address1.street}" class="form-control" placeholder="Street" data-funky="id-0">\n</div>\n<div class="form-group">\n<label for="bill-addresses-1-street">Street</label>\n<input type="text" name="bill[addresses][][street]" id="bill-addresses-1-street" value="#{@address2.street}" class="form-control" placeholder="Street" data-funky="id-1">\n</div>\n<label for="bill-ensure-names">Ensure names</label>\n</fieldset>\n<button type="submit" class="btn btn-default">Update</button>\n</form>\n))
+        expected = %(
+        <form action="/bills/#{@bill.id}" method="POST" accept-charset="utf-8" id="bill-form" class="form-horizontal">
+        <input type="hidden" name="_method" value="PATCH">
+        <input type="hidden" name="_csrf_token" value="#{@session[:_csrf_token]}">
+        <fieldset>
+        <legend>Addresses</legend>
+        <div class="form-group">
+        <label for="bill-addresses-0-street">Street</label>
+        <input type="text" name="bill[addresses][0][street]" id="bill-addresses-0-street" value="#{@address1.street}" class="form-control" placeholder="Street" data-funky="id-0">
+        </div>
+        <div class="form-group">
+        <label for="bill-addresses-0-city">City</label>
+        <input type="text" name="bill[addresses][0][city]" id="bill-addresses-0-city" value="#{@address1.city}" class="form-control" placeholder="City" data-funky="id-0">
+        </div>
+        <div class="form-group">
+        <label for="bill-addresses-1-street">Street</label>
+        <input type="text" name="bill[addresses][1][street]" id="bill-addresses-1-street" value="#{@address2.street}" class="form-control" placeholder="Street" data-funky="id-1">
+        </div>
+        <div class="form-group">
+        <label for="bill-addresses-1-city">City</label>
+        <input type="text" name="bill[addresses][1][city]" id="bill-addresses-1-city" value="#{@address2.city}" class="form-control" placeholder="City" data-funky="id-1">
+        </div>
+        <label for="bill-ensure-names">Ensure names</label>
+        </fieldset>
+        <button type="submit" class="btn btn-default">Update</button>
+        </form>
+        ).strip.split("\n").map(&:strip).join("\n")
+
+        expect(@actual).to include(expected)
       end
     end
 
     describe 'after a failed submission' do
       before do
-        @address1 = Address.new(street: '5th Ave')
-        @address2 = Address.new(street: '4th Ave')
+        @address1 = Address.new(street: '5th Ave', city: 'New York')
+        @address2 = Address.new(street: '4th Ave', city: 'Seattle')
         @bill     = Bill.new(id: 1, addresses: [@address1, @address2])
         @params   = BillParams.new(bill: { addresses: [{ street: 'Mulholland Drive' }, { street: 'Quaint Edge' }] })
         @session  = Session.new(_csrf_token: 's14')
@@ -117,7 +145,35 @@ RSpec.describe 'Form helper' do
       end
 
       it 'renders the form' do
-        expect(@actual).to include(%(<form action="/bills/#{@bill.id}" method="POST" accept-charset="utf-8" id="bill-form" class="form-horizontal">\n<input type="hidden" name="_method" value="PATCH">\n<input type="hidden" name="_csrf_token" value="#{@session[:_csrf_token]}">\n<fieldset>\n<legend>Addresses</legend>\n<div class="form-group">\n<label for="bill-addresses-0-street">Street</label>\n<input type="text" name="bill[addresses][][street]" id="bill-addresses-0-street" value="#{@params[:bill][:addresses][0][:street]}" class="form-control" placeholder="Street" data-funky="id-0">\n</div>\n<div class="form-group">\n<label for="bill-addresses-1-street">Street</label>\n<input type="text" name="bill[addresses][][street]" id="bill-addresses-1-street" value="#{@params[:bill][:addresses][1][:street]}" class="form-control" placeholder="Street" data-funky="id-1">\n</div>\n<label for="bill-ensure-names">Ensure names</label>\n</fieldset>\n<button type="submit" class="btn btn-default">Update</button>\n</form>\n))
+        expected = %(
+        <form action="/bills/#{@bill.id}" method="POST" accept-charset="utf-8" id="bill-form" class="form-horizontal">
+        <input type="hidden" name="_method" value="PATCH">
+        <input type="hidden" name="_csrf_token" value="#{@session[:_csrf_token]}">
+        <fieldset>
+        <legend>Addresses</legend>
+        <div class="form-group">
+        <label for="bill-addresses-0-street">Street</label>
+        <input type="text" name="bill[addresses][0][street]" id="bill-addresses-0-street" value="#{@params[:bill][:addresses][0][:street]}" class="form-control" placeholder="Street" data-funky="id-0">
+        </div>
+        <div class="form-group">
+        <label for="bill-addresses-0-city">City</label>
+        <input type="text" name="bill[addresses][0][city]" id="bill-addresses-0-city" value="#{@address1.city}" class="form-control" placeholder="City" data-funky="id-0">
+        </div>
+        <div class="form-group">
+        <label for="bill-addresses-1-street">Street</label>
+        <input type="text" name="bill[addresses][1][street]" id="bill-addresses-1-street" value="#{@params[:bill][:addresses][1][:street]}" class="form-control" placeholder="Street" data-funky="id-1">
+        </div>
+        <div class="form-group">
+        <label for="bill-addresses-1-city">City</label>
+        <input type="text" name="bill[addresses][1][city]" id="bill-addresses-1-city" value="#{@address2.city}" class="form-control" placeholder="City" data-funky="id-1">
+        </div>
+        <label for="bill-ensure-names">Ensure names</label>
+        </fieldset>
+        <button type="submit" class="btn btn-default">Update</button>
+        </form>
+        ).strip.split("\n").map(&:strip).join("\n")
+
+        expect(@actual).to include(expected)
       end
     end
   end

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -377,10 +377,11 @@ class SessionFormHelperView < FormHelperView
 end
 
 class Address
-  attr_reader :street
+  attr_reader :street, :city
 
   def initialize(attributes = {})
     @street = attributes[:street]
+    @city   = attributes[:city]
   end
 end
 

--- a/spec/support/fixtures/templates/bills/edit.html.erb
+++ b/spec/support/fixtures/templates/bills/edit.html.erb
@@ -8,6 +8,10 @@
           label :street
           input_text :street, class: 'form-control', placeholder: 'Street', 'data-funky': "id-#{i}"
         end
+        div class: 'form-group' do
+          label :city
+          input_text :city, class: 'form-control', placeholder: 'City', 'data-funky': "id-#{i}"
+        end
       end
 
       label :ensure_names

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -377,10 +377,11 @@ class SessionFormHelperView < FormHelperView
 end
 
 class Address
-  attr_reader :street
+  attr_reader :street, :city
 
   def initialize(attributes = {})
     @street = attributes[:street]
+    @city   = attributes[:city]
   end
 end
 

--- a/test/fixtures/templates/bills/edit.html.erb
+++ b/test/fixtures/templates/bills/edit.html.erb
@@ -8,6 +8,10 @@
           label :street
           input_text :street, class: 'form-control', placeholder: 'Street', 'data-funky': "id-#{i}"
         end
+        div class: 'form-group' do
+          label :city
+          input_text :city, class: 'form-control', placeholder: 'City', 'data-funky': "id-#{i}"
+        end
       end
 
       label :ensure_names

--- a/test/integration/form_helper_test.rb
+++ b/test/integration/form_helper_test.rb
@@ -93,8 +93,8 @@ describe 'Form helper' do
   describe 'form with nested structures' do
     describe 'first page load' do
       before do
-        @address1 = Address.new(street: '5th Ave')
-        @address2 = Address.new(street: '4th Ave')
+        @address1 = Address.new(street: '5th Ave', city: 'New York')
+        @address2 = Address.new(street: '4th Ave', city: 'Seattle')
         @bill     = Bill.new(id: 1, addresses: [@address1, @address2])
         @params   = BillParams.new({})
         @session  = Session.new(_csrf_token: 's14')
@@ -103,14 +103,42 @@ describe 'Form helper' do
       end
 
       it 'renders the form' do
-        @actual.must_include %(<form action="/bills/#{@bill.id}" method="POST" accept-charset="utf-8" id="bill-form" class="form-horizontal">\n<input type="hidden" name="_method" value="PATCH">\n<input type="hidden" name="_csrf_token" value="#{@session[:_csrf_token]}">\n<fieldset>\n<legend>Addresses</legend>\n<div class="form-group">\n<label for="bill-addresses-0-street">Street</label>\n<input type="text" name="bill[addresses][][street]" id="bill-addresses-0-street" value="#{@address1.street}" class="form-control" placeholder="Street" data-funky="id-0">\n</div>\n<div class="form-group">\n<label for="bill-addresses-1-street">Street</label>\n<input type="text" name="bill[addresses][][street]" id="bill-addresses-1-street" value="#{@address2.street}" class="form-control" placeholder="Street" data-funky="id-1">\n</div>\n<label for="bill-ensure-names">Ensure names</label>\n</fieldset>\n<button type="submit" class="btn btn-default">Update</button>\n</form>\n)
+        expected = %(
+        <form action="/bills/#{@bill.id}" method="POST" accept-charset="utf-8" id="bill-form" class="form-horizontal">
+        <input type="hidden" name="_method" value="PATCH">
+        <input type="hidden" name="_csrf_token" value="#{@session[:_csrf_token]}">
+        <fieldset>
+        <legend>Addresses</legend>
+        <div class="form-group">
+        <label for="bill-addresses-0-street">Street</label>
+        <input type="text" name="bill[addresses][0][street]" id="bill-addresses-0-street" value="#{@address1.street}" class="form-control" placeholder="Street" data-funky="id-0">
+        </div>
+        <div class="form-group">
+        <label for="bill-addresses-0-city">City</label>
+        <input type="text" name="bill[addresses][0][city]" id="bill-addresses-0-city" value="#{@address1.city}" class="form-control" placeholder="City" data-funky="id-0">
+        </div>
+        <div class="form-group">
+        <label for="bill-addresses-1-street">Street</label>
+        <input type="text" name="bill[addresses][1][street]" id="bill-addresses-1-street" value="#{@address2.street}" class="form-control" placeholder="Street" data-funky="id-1">
+        </div>
+        <div class="form-group">
+        <label for="bill-addresses-1-city">City</label>
+        <input type="text" name="bill[addresses][1][city]" id="bill-addresses-1-city" value="#{@address2.city}" class="form-control" placeholder="City" data-funky="id-1">
+        </div>
+        <label for="bill-ensure-names">Ensure names</label>
+        </fieldset>
+        <button type="submit" class="btn btn-default">Update</button>
+        </form>
+        ).strip.split("\n").map(&:strip).join("\n")
+
+        @actual.must_include expected
       end
     end
 
     describe 'after a failed submission' do
       before do
-        @address1 = Address.new(street: '5th Ave')
-        @address2 = Address.new(street: '4th Ave')
+        @address1 = Address.new(street: '5th Ave', city: 'New York')
+        @address2 = Address.new(street: '4th Ave', city: 'Seattle')
         @bill     = Bill.new(id: 1, addresses: [@address1, @address2])
         @params   = BillParams.new(bill: { addresses: [{ street: 'Mulholland Drive' }, { street: 'Quaint Edge' }] })
         @session  = Session.new(_csrf_token: 's14')
@@ -119,7 +147,35 @@ describe 'Form helper' do
       end
 
       it 'renders the form' do
-        @actual.must_include %(<form action="/bills/#{@bill.id}" method="POST" accept-charset="utf-8" id="bill-form" class="form-horizontal">\n<input type="hidden" name="_method" value="PATCH">\n<input type="hidden" name="_csrf_token" value="#{@session[:_csrf_token]}">\n<fieldset>\n<legend>Addresses</legend>\n<div class="form-group">\n<label for="bill-addresses-0-street">Street</label>\n<input type="text" name="bill[addresses][][street]" id="bill-addresses-0-street" value="#{@params[:bill][:addresses][0][:street]}" class="form-control" placeholder="Street" data-funky="id-0">\n</div>\n<div class="form-group">\n<label for="bill-addresses-1-street">Street</label>\n<input type="text" name="bill[addresses][][street]" id="bill-addresses-1-street" value="#{@params[:bill][:addresses][1][:street]}" class="form-control" placeholder="Street" data-funky="id-1">\n</div>\n<label for="bill-ensure-names">Ensure names</label>\n</fieldset>\n<button type="submit" class="btn btn-default">Update</button>\n</form>\n)
+        expected = %(
+        <form action="/bills/#{@bill.id}" method="POST" accept-charset="utf-8" id="bill-form" class="form-horizontal">
+        <input type="hidden" name="_method" value="PATCH">
+        <input type="hidden" name="_csrf_token" value="#{@session[:_csrf_token]}">
+        <fieldset>
+        <legend>Addresses</legend>
+        <div class="form-group">
+        <label for="bill-addresses-0-street">Street</label>
+        <input type="text" name="bill[addresses][0][street]" id="bill-addresses-0-street" value="#{@params[:bill][:addresses][0][:street]}" class="form-control" placeholder="Street" data-funky="id-0">
+        </div>
+        <div class="form-group">
+        <label for="bill-addresses-0-city">City</label>
+        <input type="text" name="bill[addresses][0][city]" id="bill-addresses-0-city" value="#{@address1.city}" class="form-control" placeholder="City" data-funky="id-0">
+        </div>
+        <div class="form-group">
+        <label for="bill-addresses-1-street">Street</label>
+        <input type="text" name="bill[addresses][1][street]" id="bill-addresses-1-street" value="#{@params[:bill][:addresses][1][:street]}" class="form-control" placeholder="Street" data-funky="id-1">
+        </div>
+        <div class="form-group">
+        <label for="bill-addresses-1-city">City</label>
+        <input type="text" name="bill[addresses][1][city]" id="bill-addresses-1-city" value="#{@address2.city}" class="form-control" placeholder="City" data-funky="id-1">
+        </div>
+        <label for="bill-ensure-names">Ensure names</label>
+        </fieldset>
+        <button type="submit" class="btn btn-default">Update</button>
+        </form>
+        ).strip.split("\n").map(&:strip).join("\n")
+
+        @actual.must_include expected
       end
     end
   end


### PR DESCRIPTION
before this patch

    fields_for_collection :addresses do
      text_field :street
      text_field :city
    end

would generate

    <input type="text" name="delivery[addresses][][street]">
    <input type="text" name="delivery[addresses][][city]">

which, in turn, would be interpreted as

    {
      addresses: [
        { street: '...' },
        { city: '...' },
        ...
      ]
    }

which is not wanted because all fields within the set should relate to one item of the set.

with the proper indexing in the name attribute we instead get

    <input type="text" name="delivery[addresses][0][street]">
    <input type="text" name="delivery[addresses][0][city]">

and proper interpretation

    {
      addresses: [
        { street: '...', city: '...' },
        ...
      ]
    }


with my changes one can actually generate form fields for multiple objects in of a collection and it'll keep the indexes.