### PR TITLE
Form helper: disable option for select prompt

### DIFF
--- a/lib/hanami/helpers/form_helper/form_builder.rb
+++ b/lib/hanami/helpers/form_helper/form_builder.rb
@@ -1239,7 +1239,7 @@ module Hanami
           selected   = options.delete(:selected)
 
           super(attributes) do
-            option(prompt, disabled: DISABLED) unless prompt.nil?
+            _prompt(name, prompt, selected)
 
             already_selected = nil
             values.each do |content, value|
@@ -1596,6 +1596,20 @@ module Hanami
           !input_value.nil? &&
             (input_value.to_s == value.to_s || input_value.is_a?(TrueClass) ||
             input_value.is_a?(Array) && input_value.include?(value))
+        end
+
+        # @api private
+        # @since x.x.x
+        #
+        # @see Hanami::Helpers::FormHelper::FormBuilder#select
+        def _prompt(name, prompt, selected)
+          return if prompt.nil?
+
+          if selected.nil? && _value(name).nil?
+            option(prompt, disabled: DISABLED, selected: SELECTED)
+          else
+            option(prompt, disabled: DISABLED)
+          end
         end
       end
     end

--- a/lib/hanami/helpers/form_helper/form_builder.rb
+++ b/lib/hanami/helpers/form_helper/form_builder.rb
@@ -41,6 +41,14 @@ module Hanami
         # @see Hanami::Helpers::FormHelper::FormBuilder#select
         SELECTED = 'selected'.freeze
 
+        # Disabled attribute value for option
+        #
+        # @since x.x.x
+        # @api private
+        #
+        # @see Hanami::Helpers::FormHelper::FormBuilder#select
+        DISABLED = 'disabled'.freeze
+
         # Separator for accept attribute of file input
         #
         # @since 0.2.0
@@ -1231,7 +1239,7 @@ module Hanami
           selected   = options.delete(:selected)
 
           super(attributes) do
-            option(prompt) unless prompt.nil?
+            option(prompt, disabled: DISABLED) unless prompt.nil?
 
             already_selected = nil
             values.each do |content, value|

--- a/spec/unit/hanami/helpers/form_helper_spec.rb
+++ b/spec/unit/hanami/helpers/form_helper_spec.rb
@@ -2451,7 +2451,7 @@ RSpec.describe Hanami::Helpers::FormHelper do
           select :store, option_values, options: { prompt: 'Select a store' }
         end.to_s
 
-        expect(actual).to include(%(<select name="book[store]" id="book-store">\n<option disabled="disabled">Select a store</option>\n<option value="it">Italy</option>\n<option value="us">United States</option>\n</select>))
+        expect(actual).to include(%(<select name="book[store]" id="book-store">\n<option disabled="disabled" selected="selected">Select a store</option>\n<option value="it">Italy</option>\n<option value="us">United States</option>\n</select>))
       end
 
       it 'allows blank string' do
@@ -2459,7 +2459,15 @@ RSpec.describe Hanami::Helpers::FormHelper do
           select :store, option_values, options: { prompt: '' }
         end.to_s
 
-        expect(actual).to include(%(<select name="book[store]" id="book-store">\n<option disabled="disabled"></option>\n<option value="it">Italy</option>\n<option value="us">United States</option>\n</select>))
+        expect(actual).to include(%(<select name="book[store]" id="book-store">\n<option disabled="disabled" selected="selected"></option>\n<option value="it">Italy</option>\n<option value="us">United States</option>\n</select>))
+      end
+
+      it 'allows a selected value' do
+        actual = view.form_for(:book, action) do
+          select :store, option_values, options: { prompt: '', selected: 'it' }
+        end.to_s
+
+        expect(actual).to include(%(<select name="book[store]" id="book-store">\n<option disabled="disabled"></option>\n<option value="it" selected="selected">Italy</option>\n<option value="us">United States</option>\n</select>))
       end
 
       describe 'with values' do

--- a/spec/unit/hanami/helpers/form_helper_spec.rb
+++ b/spec/unit/hanami/helpers/form_helper_spec.rb
@@ -2353,7 +2353,7 @@ RSpec.describe Hanami::Helpers::FormHelper do
           select :store, option_values, multiple: true, options: { prompt: 'Choose your country' }
         end.to_s
 
-        expect(actual).to include(%(<select name="book[store][]" id="book-store" multiple="multiple">\n<option disabled="disabled">Choose your country</option>\n<option value="it">Italy</option>\n<option value="us">United States</option>\n</select>))
+        expect(actual).to include(%(<select name="book[store][]" id="book-store" multiple="multiple">\n<option disabled="disabled" selected="selected">Choose your country</option>\n<option value="it">Italy</option>\n<option value="us">United States</option>\n</select>))
       end
     end
 

--- a/spec/unit/hanami/helpers/form_helper_spec.rb
+++ b/spec/unit/hanami/helpers/form_helper_spec.rb
@@ -2347,6 +2347,14 @@ RSpec.describe Hanami::Helpers::FormHelper do
 
         expect(actual).to include(%(<select name="book[store][]" id="book-store" multiple="multiple">\n<option value="it" selected="selected">Italy</option>\n<option value="us" selected="selected">United States</option>\n</select>))
       end
+
+      it "allows a prompt" do
+        actual = view.form_for(:book, action) do
+          select :store, option_values, multiple: true, options: { prompt: 'Choose your country' }
+        end.to_s
+
+        expect(actual).to include(%(<select name="book[store][]" id="book-store" multiple="multiple">\n<option disabled="disabled">Choose your country</option>\n<option value="it">Italy</option>\n<option value="us">United States</option>\n</select>))
+      end
     end
 
     describe 'with values an structured Array of values' do
@@ -2443,7 +2451,7 @@ RSpec.describe Hanami::Helpers::FormHelper do
           select :store, option_values, options: { prompt: 'Select a store' }
         end.to_s
 
-        expect(actual).to include(%(<select name="book[store]" id="book-store">\n<option>Select a store</option>\n<option value="it">Italy</option>\n<option value="us">United States</option>\n</select>))
+        expect(actual).to include(%(<select name="book[store]" id="book-store">\n<option disabled="disabled">Select a store</option>\n<option value="it">Italy</option>\n<option value="us">United States</option>\n</select>))
       end
 
       it 'allows blank string' do
@@ -2451,7 +2459,7 @@ RSpec.describe Hanami::Helpers::FormHelper do
           select :store, option_values, options: { prompt: '' }
         end.to_s
 
-        expect(actual).to include(%(<select name="book[store]" id="book-store">\n<option></option>\n<option value="it">Italy</option>\n<option value="us">United States</option>\n</select>))
+        expect(actual).to include(%(<select name="book[store]" id="book-store">\n<option disabled="disabled"></option>\n<option value="it">Italy</option>\n<option value="us">United States</option>\n</select>))
       end
 
       describe 'with values' do
@@ -2463,7 +2471,7 @@ RSpec.describe Hanami::Helpers::FormHelper do
             select :store, option_values, options: { prompt: 'Select a store' }
           end.to_s
 
-          expect(actual).to include(%(<select name="book[store]" id="book-store">\n<option>Select a store</option>\n<option value="it" selected="selected">Italy</option>\n<option value="us">United States</option>\n</select>))
+          expect(actual).to include(%(<select name="book[store]" id="book-store">\n<option disabled="disabled">Select a store</option>\n<option value="it" selected="selected">Italy</option>\n<option value="us">United States</option>\n</select>))
         end
       end
 
@@ -2477,7 +2485,7 @@ RSpec.describe Hanami::Helpers::FormHelper do
               select :store, option_values, options: { prompt: 'Select a store' }
             end.to_s
 
-            expect(actual).to include(%(<select name="book[store]" id="book-store">\n<option>Select a store</option>\n<option value="it" selected="selected">Italy</option>\n<option value="us">United States</option>\n</select>))
+            expect(actual).to include(%(<select name="book[store]" id="book-store">\n<option disabled="disabled">Select a store</option>\n<option value="it" selected="selected">Italy</option>\n<option value="us">United States</option>\n</select>))
           end
         end
 


### PR DESCRIPTION
Prompt option shouldn't be enabled in generated select