### PR TITLE
Documentation of the `select` helper

### DIFF
--- a/lib/hanami/helpers/form_helper/form_builder.rb
+++ b/lib/hanami/helpers/form_helper/form_builder.rb
@@ -1200,6 +1200,30 @@ module Hanami
         #     <option value="it">Italy</option>
         #     <option value="us">United States</option>
         #   </select>
+        #
+        # @example Array with repeated entries
+        #   <%=
+        #     # ...
+        #     values = [['Italy', 'it'],
+        #               ['---', ''],
+        #               ['Afghanistan', 'af'],
+        #               ...
+        #               ['Italy', 'it'],
+        #               ...
+        #               ['Zimbabwe', 'zw']]
+        #     select :stores, values
+        #   %>
+        #
+        #   <!-- output -->
+        #   <select name="book[store]" id="book-store">
+        #     <option value="it">Italy</option>
+        #     <option value="">---</option>
+        #     <option value="af">Afghanistan</option>
+        #     ...
+        #     <option value="it">Italy</option>
+        #     ...
+        #     <option value="zw">Zimbabwe</option>
+        #   </select>
         def select(name, values, attributes = {}) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
           options    = attributes.delete(:options) { {} }
           attributes = { name: _select_input_name(name, attributes[:multiple]), id: _input_id(name) }.merge(attributes)

--- a/lib/hanami/helpers/form_helper/form_builder.rb
+++ b/lib/hanami/helpers/form_helper/form_builder.rb
@@ -1093,11 +1093,11 @@ module Hanami
         #   <%=
         #     # ...
         #     values = Hash['Italy' => 'it', 'United States' => 'us']
-        #     select :store, values, class: "form-control"
+        #     select :store, values
         #   %>
         #
         #   <!-- output -->
-        #   <select name="book[store]" id="book-store" class="form-control">
+        #   <select name="book[store]" id="book-store">
         #     <option value="it">Italy</option>
         #     <option value="us">United States</option>
         #   </select>
@@ -1106,11 +1106,11 @@ module Hanami
         #   <%=
         #     # ...
         #     values = Hash['Italy' => 'it', 'United States' => 'us']
-        #     select :store, values
+        #     select :store, values, class: "form-control"
         #   %>
         #
         #   <!-- output -->
-        #   <select name="book[store]" id="book-store">
+        #   <select name="book[store]" id="book-store" class="form-control">
         #     <option value="it">Italy</option>
         #     <option value="us">United States</option>
         #   </select>

--- a/lib/hanami/helpers/form_helper/form_builder.rb
+++ b/lib/hanami/helpers/form_helper/form_builder.rb
@@ -1077,8 +1077,11 @@ module Hanami
         #
         # @param name [Symbol] the input name
         # @param values [Hash] a Hash to generate <tt><option></tt> tags.
-        #   Values correspond to <tt>value</tt> and keys correspond to the content.
         # @param attributes [Hash] HTML attributes to pass to the input tag
+        #
+        # Values is used to generate the list of <tt>&lt;option&gt;</tt> tags, it is an
+        # <tt>Enumerable</tt> of pairs of content (the displayed text) and value (the tag's
+        # attribute), in that respective order (please refer to the examples for more clarity).
         #
         # If request params have a value that corresponds to one of the given values,
         # it automatically sets the <tt>selected</tt> attribute on the <tt><option></tt> tag.

--- a/spec/unit/hanami/helpers/form_helper_spec.rb
+++ b/spec/unit/hanami/helpers/form_helper_spec.rb
@@ -2372,6 +2372,18 @@ RSpec.describe Hanami::Helpers::FormHelper do
           expect(actual).to include(%(<select name="book[store]" id="book-store">\n<option value="it" selected="selected">Italy</option>\n<option value="us">United States</option>\n</select>))
         end
       end
+
+      describe 'and repeated values' do
+        let(:option_values) { [%w[Italy it], ['United States', 'us'], %w[Italy it]] }
+
+        it 'renders' do
+          actual = view.form_for(:book, action) do
+            select :store, option_values
+          end.to_s
+
+          expect(actual).to include(%(<select name="book[store]" id="book-store">\n<option value="it">Italy</option>\n<option value="us">United States</option>\n<option value="it">Italy</option>\n</select>))
+        end
+      end
     end
 
     describe 'with values an Array of objects' do


### PR DESCRIPTION
Hi,

This PR is an attempt to improve the documentation of the `select` form helper:

- it describes more thoroughly what the `values` parameter is,
- it fixes an error where two examples were inverted,
- it adds an example with an `Array` as input,
- it adds a spec to ensure that repeated entries are allowed.

The case for using something else than a `Hash` as input can be made on the ground that in some cases, it might be better for user convenience to be able to repeat entries in a select. One case could be country selection, where a handful of favourite countries are displayed first, and then the whole list (without trying to remove the favourites from that whole list).