### PR TITLE
Ensure FormBuilder#select to respect "selected" option

### DIFF
--- a/lib/hanami/helpers/form_helper/form_builder.rb
+++ b/lib/hanami/helpers/form_helper/form_builder.rb
@@ -1550,7 +1550,7 @@ module Hanami
         def _select_option_selected?(value, selected, input_value, multiple)
           value == selected ||
             (multiple && (selected.is_a?(Array) && selected.include?(value))) ||
-            value.to_s == input_value.to_s ||
+            (!input_value.nil? && (value.to_s == input_value.to_s)) ||
             (multiple && (input_value.is_a?(Array) && input_value.include?(value)))
         end
         # rubocop:enable Metrics/PerceivedComplexity

--- a/spec/unit/hanami/helpers/form_helper_spec.rb
+++ b/spec/unit/hanami/helpers/form_helper_spec.rb
@@ -2524,6 +2524,14 @@ RSpec.describe Hanami::Helpers::FormHelper do
 
         expect(actual).to include(%(<select name="book[store]" id="book-store">\n<option value="it" selected="selected">Italy</option>\n<option value="us">United States</option>\n<option value="">N&#x2F;A</option>\n</select>))
       end
+
+      it "allows to force the selection of none" do
+        actual = view.form_for(:book, action) do
+          select :store, option_values, options: { selected: 'none' }
+        end.to_s
+
+        expect(actual).to include(%(<select name="book[store]" id="book-store">\n<option value="it">Italy</option>\n<option value="us">United States</option>\n<option value="">N&#x2F;A</option>\n</select>))
+      end
     end
   end
 


### PR DESCRIPTION
Ensure `FormBuilder#select` to respect `selected:` option:

```erb
<%=
  form_for :test, '/test' do
    values = { "Italy" => "it", "---" => "" }
    select :country, values, options: { selected: 'none' }
  end
%>
```

```html
<form action="/test" method="POST" accept-charset="utf-8" id="test-form">
<select name="test[country]" id="test-country">
<option>---</option>
<option value="it">Italy</option>
</select>
</form>
```

---

Ref #120
Fixes #124 