### PR TITLE
Join attribute values with space, for arrays

### DIFF
--- a/lib/hanami/helpers/html_helper/empty_html_node.rb
+++ b/lib/hanami/helpers/html_helper/empty_html_node.rb
@@ -78,7 +78,7 @@ module Hanami
         # @api private
         def initialize(name, attributes)
           @name       = name
-          @attributes = attributes
+          @attributes = htmlified_array_attributes(attributes)
         end
 
         # Resolve and return the output
@@ -128,6 +128,21 @@ module Hanami
         # @api private
         def attribute(attribute_name, value)
           %(#{ATTRIBUTES_SEPARATOR}#{attribute_name}="#{value}")
+        end
+
+        # Changes any attributes values that are arrays into a string joined by
+        # a space, as HTML expects it.
+        #
+        # @param attributes [Hash] the attributes with values to be HTMLified
+        #
+        # @return [Hash] the attributes transformed into HTML friendly values, i.e space separated strings
+        #
+        # @since x.x.x
+        def htmlified_array_attributes(attributes)
+          attributes&.inject({}) do |attrs, (key, value)|
+            attrs[key] = value.is_a?(Array) ? value.join(" ") : value
+            attrs
+          end
         end
       end
     end

--- a/lib/hanami/helpers/html_helper/empty_html_node.rb
+++ b/lib/hanami/helpers/html_helper/empty_html_node.rb
@@ -140,7 +140,7 @@ module Hanami
         # @since x.x.x
         def htmlified_array_attributes(attributes)
           attributes&.inject({}) do |attrs, (key, value)|
-            attrs[key] = value.is_a?(Array) ? value.join(" ") : value
+            attrs[key] = value.is_a?(Array) ? value.join(ATTRIBUTES_SEPARATOR) : value
             attrs
           end
         end

--- a/lib/hanami/helpers/html_helper/empty_html_node.rb
+++ b/lib/hanami/helpers/html_helper/empty_html_node.rb
@@ -78,7 +78,7 @@ module Hanami
         # @api private
         def initialize(name, attributes)
           @name       = name
-          @attributes = htmlified_array_attributes(attributes)
+          @attributes = prepare_html_attributes(attributes)
         end
 
         # Resolve and return the output
@@ -138,7 +138,7 @@ module Hanami
         # @return [Hash] the attributes transformed into HTML friendly values, i.e space separated strings
         #
         # @since x.x.x
-        def htmlified_array_attributes(attributes)
+        def prepare_html_attributes(attributes)
           attributes&.inject({}) do |attrs, (key, value)|
             attrs[key] = value.is_a?(Array) ? value.join(ATTRIBUTES_SEPARATOR) : value
             attrs

--- a/lib/hanami/helpers/html_helper/html_node.rb
+++ b/lib/hanami/helpers/html_helper/html_node.rb
@@ -27,7 +27,8 @@ module Hanami
                        @attributes = content
                        nil
                      else
-                       @attributes = attributes.to_h if attributes.respond_to?(:to_h)
+                       attributes_hash = attributes.to_h if attributes.respond_to?(:to_h)
+                       @attributes = htmlified_array_attributes(attributes_hash)
                        content
                      end
         end

--- a/lib/hanami/helpers/html_helper/html_node.rb
+++ b/lib/hanami/helpers/html_helper/html_node.rb
@@ -27,7 +27,7 @@ module Hanami
                        nil
                      else
                        attributes_hash = attributes.to_h if attributes.respond_to?(:to_h)
-                       @attributes = htmlified_array_attributes(attributes_hash)
+                       @attributes = prepare_html_attributes(attributes_hash)
                        content
                      end
         end

--- a/lib/hanami/helpers/html_helper/html_node.rb
+++ b/lib/hanami/helpers/html_helper/html_node.rb
@@ -22,8 +22,7 @@ module Hanami
         def initialize(name, content, attributes, _options = {})
           @builder = HtmlBuilder.new
           @name    = name
-          @content = case content
-                     when Hash
+          @content = if content.is_a?(Hash)
                        @attributes = content
                        nil
                      else

--- a/spec/unit/hanami/helpers/html_helper/html_builder_spec.rb
+++ b/spec/unit/hanami/helpers/html_helper/html_builder_spec.rb
@@ -247,9 +247,14 @@ CONTENT
     end
 
     # rubocop:disable Style/SymbolArray
-    it 'renders attribute with array value as joined with string' do
+    it 'renders empty node with array value as joined with space' do
       result = @builder.input('class' => [:ui, :form]).to_s
       expect(result).to eq('<input class="ui form">')
+    end
+
+    it 'renders non-empty node with array value as joined with space' do
+      result = @builder.span('foo', 'class' => [:ui, :form]).to_s
+      expect(result).to eq('<span class="ui form">foo</span>')
     end
     # rubocop:enable Style/SymbolArray
   end

--- a/spec/unit/hanami/helpers/html_helper/html_builder_spec.rb
+++ b/spec/unit/hanami/helpers/html_helper/html_builder_spec.rb
@@ -245,6 +245,13 @@ CONTENT
       result = @builder.input('required' => true, 'value' => 'Title "book"', 'something' => 'bar').to_s
       expect(result).to eq('<input required="required" value="Title "book"" something="bar">')
     end
+
+    # rubocop:disable Style/SymbolArray
+    it 'renders attribute with array value as joined with string' do
+      result = @builder.input('class' => [:ui, :form]).to_s
+      expect(result).to eq('<input class="ui form">')
+    end
+    # rubocop:enable Style/SymbolArray
   end
 
   ##############################################################################


### PR DESCRIPTION
Without this change, `class: [:ui, :form]` renders, in HTML, as:

```html
class="["ui", "form"]
```
which is not what a developer would expect.

With this change, `class: [:ui, :form]` renders, in HTML, as:

```html
 class="ui form"
```
 as one would expect.

Note: I implemented this for _all_ attributes, not just `class`. I'm not sure if that makes sense? I can't think of other attributes that would act this way.

If we only want to do this for `class`, it actually makes the code more perform better, since we don't have to go through the process of iterating through the Hash and creating a new copy of it.

I also only wrote the spec for `input`, but we should have it for all the attributes. Just wanted to make sure others were interested in this change before I went through the manual work for doing that? (Or can we add some spec elsewhere?)

What do you think @hanami/core and others?