### PR TITLE
Extend helpers to support UJS markup

### DIFF
--- a/lib/hanami/helpers/form_helper.rb
+++ b/lib/hanami/helpers/form_helper.rb
@@ -1,4 +1,5 @@
 require 'hanami/helpers/form_helper/form_builder'
+require 'hanami/helpers/html_helper'
 
 module Hanami
   module Helpers
@@ -96,6 +97,8 @@ module Hanami
       # @since 0.2.0
       # @api private
       CSRF_TOKEN = :_csrf_token
+
+      include HtmlHelper
 
       # Form object
       #
@@ -431,6 +434,36 @@ module Hanami
         elsif defined?(locals) && locals[:session]
           locals[:session][CSRF_TOKEN]
         end
+      end
+
+      # Prints CSRF meta tags for Unobtrusive JavaScript (UJS) purposes.
+      #
+      # @return [Hanami::Helpers::HtmlHelper::HtmlBuilder,NilClass] the tags if `csrf_token` is not `nil`
+      #
+      # @since x.x.x
+      #
+      # @example
+      #   <html>
+      #     <head>
+      #       <!-- ... -->
+      #       <%= csrf_meta_tags %>
+      #     </head>
+      #     <!-- ... -->
+      #   </html>
+      #
+      #   <html>
+      #     <head>
+      #       <!-- ... -->
+      #       <meta name="csrf-param" value="_csrf_token">
+      #       <meta name="csrf-token" value="4a038be85b7603c406dcbfad4b9cdf91ec6ca138ed6441163a07bb0fdfbe25b5">
+      #     </head>
+      #     <!-- ... -->
+      #   </html>
+      def csrf_meta_tags
+        return if csrf_token.nil?
+
+        html.meta(name: "csrf-param", value: CSRF_TOKEN) +
+          html.meta(name: "csrf-token", value: csrf_token)
       end
     end
   end

--- a/lib/hanami/helpers/form_helper.rb
+++ b/lib/hanami/helpers/form_helper.rb
@@ -417,7 +417,10 @@ module Hanami
                  Form.new(name, url, options.delete(:values))
                end
 
-        attributes = { action: form.url, method: form.verb, 'accept-charset': DEFAULT_CHARSET, id: "#{form.name}-form" }.merge(options)
+        opts = options.dup
+        opts[:"data-remote"] = opts.delete(:remote) if opts.key?(:remote)
+        attributes = { action: form.url, method: form.verb, 'accept-charset': DEFAULT_CHARSET, id: "#{form.name}-form" }.merge(opts)
+
         FormBuilder.new(form, attributes, self, &blk)
       end
 

--- a/spec/unit/hanami/helpers/form_helper_spec.rb
+++ b/spec/unit/hanami/helpers/form_helper_spec.rb
@@ -92,6 +92,24 @@ RSpec.describe Hanami::Helpers::FormHelper do
         end
       end
     end
+
+    describe "CSRF meta tags" do
+      let(:view)       { SessionFormHelperView.new(params, csrf_token) }
+      let(:csrf_token) { 'abc123' }
+
+      it "prints meta tags" do
+        expected = %(<meta name="csrf-param" value="_csrf_token">\n<meta name="csrf-token" value="#{csrf_token}">)
+        expect(view.csrf_meta_tags.to_s).to eq(expected)
+      end
+
+      context "when CSRF token is nil" do
+        let(:csrf_token) { nil }
+
+        it "returns nil" do
+          expect(view.csrf_meta_tags).to be(nil)
+        end
+      end
+    end
   end
 
   #

--- a/spec/unit/hanami/helpers/form_helper_spec.rb
+++ b/spec/unit/hanami/helpers/form_helper_spec.rb
@@ -110,6 +110,23 @@ RSpec.describe Hanami::Helpers::FormHelper do
         end
       end
     end
+
+    describe "remote: true" do
+      it "adds data-remote=true to form attributes" do
+        actual = view.form_for(:book, action, remote: true) {}
+        expect(actual.to_s).to eq(%(<form action="/books" method="POST" accept-charset="utf-8" id="book-form" data-remote="true">\n\n</form>))
+      end
+
+      it "adds data-remote=false to form attributes" do
+        actual = view.form_for(:book, action, remote: false) {}
+        expect(actual.to_s).to eq(%(<form action="/books" method="POST" accept-charset="utf-8" id="book-form" data-remote="false">\n\n</form>))
+      end
+
+      it "adds data-remote= to form attributes" do
+        actual = view.form_for(:book, action, remote: nil) {}
+        expect(actual.to_s).to eq(%(<form action="/books" method="POST" accept-charset="utf-8" id="book-form" data-remote="">\n\n</form>))
+      end
+    end
   end
 
   #


### PR DESCRIPTION
This PR introduces:

  - [x] `csrf_meta_tags` helper to print meta tags for CSRF protection
  - [x] `form_for(..., remote: true)` translates into `<form ... data-remote="true">`