### PR TITLE
fix select with values and nil options

### DIFF
--- a/lib/hanami/helpers/form_helper/form_builder.rb
+++ b/lib/hanami/helpers/form_helper/form_builder.rb
@@ -81,11 +81,11 @@ module Hanami
 
         # Instantiate a form builder
         #
-        # @overload initialize(form, attributes, params, &blk)
+        # @overload initialize(form, attributes, context, &blk)
         #   Top level form
         #   @param form [Hanami::Helpers:FormHelper::Form] the form
         #   @param attributes [::Hash] a set of HTML attributes
-        #   @param params [Hanami::Action::Params] request params
+        #   @param context [Hanami::Helpers::FormHelper]
         #   @param blk [Proc] a block that describes the contents of the form
         #
         # @overload initialize(form, attributes, params, &blk)

--- a/lib/hanami/helpers/form_helper/form_builder.rb
+++ b/lib/hanami/helpers/form_helper/form_builder.rb
@@ -1225,10 +1225,11 @@ module Hanami
         #     <option value="zw">Zimbabwe</option>
         #   </select>
         def select(name, values, attributes = {}) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
-          options    = attributes.delete(:options) { {} }
-          attributes = { name: _select_input_name(name, attributes[:multiple]), id: _input_id(name) }.merge(attributes)
-          prompt     = options.delete(:prompt)
-          selected   = options.delete(:selected)
+          options     = attributes.delete(:options) { {} }
+          multiple    = attributes[:multiple]
+          attributes  = { name: _select_input_name(name, multiple), id: _input_id(name) }.merge(attributes)
+          prompt      = options.delete(:prompt)
+          selected    = options.delete(:selected)
           input_value = _value(name)
 
           super(attributes) do
@@ -1236,7 +1237,7 @@ module Hanami
 
             already_selected = nil
             values.each do |content, value|
-              if (attributes[:multiple] || !already_selected) && (already_selected = _select_option_selected?(value, selected, input_value, attributes[:multiple]))
+              if (multiple || !already_selected) && (already_selected = _select_option_selected?(value, selected, input_value, multiple))
                 option(content, { value: value, selected: SELECTED }.merge(options))
               else
                 option(content, { value: value }.merge(options))

--- a/lib/hanami/helpers/form_helper/form_builder.rb
+++ b/lib/hanami/helpers/form_helper/form_builder.rb
@@ -1575,10 +1575,14 @@ module Hanami
         # rubocop:disable Metrics/CyclomaticComplexity
         # rubocop:disable Metrics/PerceivedComplexity
         def _select_option_selected?(value, selected, input_value, multiple)
-          value == selected ||
-            (multiple && (selected.is_a?(Array) && selected.include?(value))) ||
-            (!input_value.nil? && (value.to_s == input_value.to_s)) ||
-            (multiple && (input_value.is_a?(Array) && input_value.include?(value)))
+          if input_value && selected.nil?
+            value.to_s == input_value
+          else
+            (value == selected) ||
+              (multiple && (selected.is_a?(Array) && selected.include?(value))) ||
+              (!input_value.nil? && (value.to_s == input_value.to_s)) ||
+              (multiple && (input_value.is_a?(Array) && input_value.include?(value)))
+          end
         end
         # rubocop:enable Metrics/PerceivedComplexity
         # rubocop:enable Metrics/CyclomaticComplexity

--- a/lib/hanami/helpers/form_helper/form_builder.rb
+++ b/lib/hanami/helpers/form_helper/form_builder.rb
@@ -1570,24 +1570,35 @@ module Hanami
           select_name
         end
 
-        # TODO: this has to be refactored
-        #
         # @api private
-        #
-        # rubocop:disable Metrics/CyclomaticComplexity
-        # rubocop:disable Metrics/PerceivedComplexity
         def _select_option_selected?(value, selected, input_value, multiple)
           if input_value && selected.nil?
             value.to_s == input_value
           else
             (value == selected) ||
-              (multiple && (selected.is_a?(Array) && selected.include?(value))) ||
-              (!input_value.nil? && (value.to_s == input_value.to_s)) ||
-              (multiple && (input_value.is_a?(Array) && input_value.include?(value)))
+              _is_in_selected_values?(multiple, selected, value) ||
+              _is_current_value?(input_value, value) ||
+              _is_in_input_values?(multiple, input_value, value)
           end
         end
-        # rubocop:enable Metrics/PerceivedComplexity
-        # rubocop:enable Metrics/CyclomaticComplexity
+
+        # @api private
+        def _is_current_value?(input_value, value)
+          return unless input_value
+          value.to_s == input_value.to_s
+        end
+
+        # @api private
+        def _is_in_selected_values?(multiple, selected, value)
+          return unless multiple && selected.is_a?(Array)
+          selected.include?(value)
+        end
+
+        # @api private
+        def _is_in_input_values?(multiple, input_value, value)
+          return unless multiple && input_value.is_a?(Array)
+          input_value.include?(value)
+        end
 
         # @api private
         def _check_box_checked?(value, input_value)

--- a/lib/hanami/helpers/form_helper/form_builder.rb
+++ b/lib/hanami/helpers/form_helper/form_builder.rb
@@ -1229,13 +1229,14 @@ module Hanami
           attributes = { name: _select_input_name(name, attributes[:multiple]), id: _input_id(name) }.merge(attributes)
           prompt     = options.delete(:prompt)
           selected   = options.delete(:selected)
+          input_value = _value(name)
 
           super(attributes) do
             option(prompt) unless prompt.nil?
 
             already_selected = nil
             values.each do |content, value|
-              if (attributes[:multiple] || !already_selected) && (already_selected = _select_option_selected?(value, selected, _value(name), attributes[:multiple]))
+              if (attributes[:multiple] || !already_selected) && (already_selected = _select_option_selected?(value, selected, input_value, attributes[:multiple]))
                 option(content, { value: value, selected: SELECTED }.merge(options))
               else
                 option(content, { value: value }.merge(options))

--- a/spec/unit/hanami/helpers/form_helper_spec.rb
+++ b/spec/unit/hanami/helpers/form_helper_spec.rb
@@ -2546,9 +2546,9 @@ RSpec.describe Hanami::Helpers::FormHelper do
       end
 
       describe 'with values' do
-        let(:values) { Hash[book: Book.new(category: val)] }
-        let(:option_values) {  Hash['N/A' => nil, 'Horror' => 'horror', 'SciFy' => 'scify'] }
-        let(:val) { 'horror' }
+        let(:values)        { Hash[book: Book.new(category: val)] }
+        let(:option_values) { Hash['N/A' => nil, 'Horror' => 'horror', 'SciFy' => 'scify'] }
+        let(:val)           { 'horror' }
 
         it 'sets correct value as selected' do
           actual = view.form_for(:book, action, values: values) do

--- a/spec/unit/hanami/helpers/form_helper_spec.rb
+++ b/spec/unit/hanami/helpers/form_helper_spec.rb
@@ -2544,6 +2544,20 @@ RSpec.describe Hanami::Helpers::FormHelper do
 
         expect(actual).to include(%(<select name="book[store]" id="book-store">\n<option value="it">Italy</option>\n<option value="us">United States</option>\n<option value="">N&#x2F;A</option>\n</select>))
       end
+
+      describe 'with values' do
+        let(:values) { Hash[book: Book.new(category: val)] }
+        let(:option_values) {  Hash['N/A' => nil, 'Horror' => 'horror', 'SciFy' => 'scify'] }
+        let(:val) { 'horror' }
+
+        it 'sets correct value as selected' do
+          actual = view.form_for(:book, action, values: values) do
+            select :category, option_values
+          end.to_s
+
+          expect(actual).to include(%(<form action="/books" method="POST" accept-charset="utf-8" id="book-form">\n<select name="book[category]" id="book-category">\n<option value="">N&#x2F;A</option>\n<option value="horror" selected="selected">Horror</option>\n<option value="scify">SciFy</option>\n</select>\n</form>))
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Fixes #131

@nerdinand can you take a look this fix?

@jodosha I was playing with this bug and decided to make the first contribution 🎉 

The bug was originated because of the `selected` been set as `nil` and the first value been `nil` as well.

If we are happy with the end result I would like to refactor `_select_option_selected?` before merging.