### PR TITLE
fields_for_collection: pass resource in block

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ tmp
 mkmf.log
 .greenbar
 .rubocop-*
+.byebug_history

--- a/lib/hanami/helpers/form_helper/form_builder.rb
+++ b/lib/hanami/helpers/form_helper/form_builder.rb
@@ -243,9 +243,17 @@ module Hanami
           base_value = _value(name)
           @name = _input_name(name)
 
-          base_value.count.times do |index|
-            fields_for(index, &block)
+          base_value.each_with_index do |value, index|
+            _collection_fields_for(value, index, &block)
           end
+        ensure
+          @name = current_name
+        end
+
+        def _collection_fields_for(value, index)
+          current_name = @name
+          @name        = _input_name(index)
+          yield(index, value)
         ensure
           @name = current_name
         end

--- a/spec/integration/form_helper_spec.rb
+++ b/spec/integration/form_helper_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe 'Form helper' do
       end
 
       it 'renders the form' do
-        expect(@actual).to include(%(<form action="/bills/#{@bill.id}" method="POST" accept-charset="utf-8" id="bill-form" class="form-horizontal">\n<input type="hidden" name="_method" value="PATCH">\n<input type="hidden" name="_csrf_token" value="#{@session[:_csrf_token]}">\n<fieldset>\n<legend>Addresses</legend>\n<div class="form-group">\n<label for="bill-addresses-0-street">Street</label>\n<input type="text" name="bill[addresses][][street]" id="bill-addresses-0-street" value="#{@address1.street}" class="form-control" placeholder="Street" data-funky="id-0">\n</div>\n<div class="form-group">\n<label for="bill-addresses-1-street">Street</label>\n<input type="text" name="bill[addresses][][street]" id="bill-addresses-1-street" value="#{@address2.street}" class="form-control" placeholder="Street" data-funky="id-1">\n</div>\n<label for="bill-ensure-names">Ensure names</label>\n</fieldset>\n<button type="submit" class="btn btn-default">Update</button>\n</form>\n))
+        expect(@actual).to include(%(<form action="/bills/#{@bill.id}" method="POST" accept-charset="utf-8" id="bill-form" class="form-horizontal">\n<input type="hidden" name="_method" value="PATCH">\n<input type="hidden" name="_csrf_token" value="#{@session[:_csrf_token]}">\n<fieldset>\n<legend>Addresses</legend>\n<div class="form-group">\n<label for="bill-addresses-0-street">Street</label>\n<input type="text" name="bill[addresses][][street]" id="bill-addresses-0-street" value="#{@address1.street}" class="form-control" placeholder="Street" data-funky="index-0">\n</div>\n<div class="form-group">\n<label for="bill-addresses-1-street">Street</label>\n<input type="text" name="bill[addresses][][street]" id="bill-addresses-1-street" value="#{@address2.street}" class="form-control" placeholder="Street" data-funky="index-1">\n</div>\n<label for="bill-ensure-names">Ensure names</label>\n</fieldset>\n<button type="submit" class="btn btn-default">Update</button>\n</form>\n))
       end
     end
 
@@ -117,7 +117,23 @@ RSpec.describe 'Form helper' do
       end
 
       it 'renders the form' do
-        expect(@actual).to include(%(<form action="/bills/#{@bill.id}" method="POST" accept-charset="utf-8" id="bill-form" class="form-horizontal">\n<input type="hidden" name="_method" value="PATCH">\n<input type="hidden" name="_csrf_token" value="#{@session[:_csrf_token]}">\n<fieldset>\n<legend>Addresses</legend>\n<div class="form-group">\n<label for="bill-addresses-0-street">Street</label>\n<input type="text" name="bill[addresses][][street]" id="bill-addresses-0-street" value="#{@params[:bill][:addresses][0][:street]}" class="form-control" placeholder="Street" data-funky="id-0">\n</div>\n<div class="form-group">\n<label for="bill-addresses-1-street">Street</label>\n<input type="text" name="bill[addresses][][street]" id="bill-addresses-1-street" value="#{@params[:bill][:addresses][1][:street]}" class="form-control" placeholder="Street" data-funky="id-1">\n</div>\n<label for="bill-ensure-names">Ensure names</label>\n</fieldset>\n<button type="submit" class="btn btn-default">Update</button>\n</form>\n))
+        expect(@actual).to include(%(<form action="/bills/#{@bill.id}" method="POST" accept-charset="utf-8" id="bill-form" class="form-horizontal">\n<input type="hidden" name="_method" value="PATCH">\n<input type="hidden" name="_csrf_token" value="#{@session[:_csrf_token]}">\n<fieldset>\n<legend>Addresses</legend>\n<div class="form-group">\n<label for="bill-addresses-0-street">Street</label>\n<input type="text" name="bill[addresses][][street]" id="bill-addresses-0-street" value="#{@params[:bill][:addresses][0][:street]}" class="form-control" placeholder="Street" data-funky="index-0">\n</div>\n<div class="form-group">\n<label for="bill-addresses-1-street">Street</label>\n<input type="text" name="bill[addresses][][street]" id="bill-addresses-1-street" value="#{@params[:bill][:addresses][1][:street]}" class="form-control" placeholder="Street" data-funky="index-1">\n</div>\n<label for="bill-ensure-names">Ensure names</label>\n</fieldset>\n<button type="submit" class="btn btn-default">Update</button>\n</form>\n))
+      end
+    end
+
+    describe 'accessing resource data' do
+      before do
+        @address1 = Address.new(id: 23, street: '5th Ave')
+        @address2 = Address.new(id: 42, street: '4th Ave')
+        @bill     = Bill.new(id: 1, addresses: [@address1, @address2])
+        @params   = BillParams.new({})
+        @session  = Session.new(_csrf_token: 's14')
+
+        @actual   = FullStack::Views::Bills::Edit2.render(format: :html, bill: @bill, params: @params, session: @session)
+      end
+
+      it 'renders the form' do
+        expect(@actual).to include(%(<form action="/bills/#{@bill.id}" method="POST" accept-charset="utf-8" id="bill-form" class="form-horizontal">\n<input type="hidden" name="_method" value="PATCH">\n<input type="hidden" name="_csrf_token" value="#{@session[:_csrf_token]}">\n<fieldset>\n<legend>Addresses</legend>\n<div class="form-group">\nAddress id: 23\n<label for="bill-addresses-0-street">Street</label>\n<input type="text" name="bill[addresses][][street]" id="bill-addresses-0-street" value="#{@address1.street}" class="form-control" placeholder="Street" data-funky="index-0">\n</div>\n<div class="form-group">\nAddress id: 42\n<label for="bill-addresses-1-street">Street</label>\n<input type="text" name="bill[addresses][][street]" id="bill-addresses-1-street" value="#{@address2.street}" class="form-control" placeholder="Street" data-funky="index-1">\n</div>\n<label for="bill-ensure-names">Ensure names</label>\n</fieldset>\n<button type="submit" class="btn btn-default">Update</button>\n</form>\n))
       end
     end
   end

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -377,9 +377,10 @@ class SessionFormHelperView < FormHelperView
 end
 
 class Address
-  attr_reader :street
+  attr_reader :id, :street
 
   def initialize(attributes = {})
+    @id     = attributes[:id]
     @street = attributes[:street]
   end
 end
@@ -534,6 +535,19 @@ module FullStack
       class Edit
         include TestView
         template 'bills/edit'
+
+        def form
+          Form.new(:bill, routes.bill_path(id: bill.id), { bill: bill }, method: :patch)
+        end
+
+        def submit_label
+          'Update'
+        end
+      end
+
+      class Edit2
+        include TestView
+        template 'bills/edit2'
 
         def form
           Form.new(:bill, routes.bill_path(id: bill.id), { bill: bill }, method: :patch)

--- a/spec/support/fixtures/templates/bills/edit2.html.erb
+++ b/spec/support/fixtures/templates/bills/edit2.html.erb
@@ -3,8 +3,10 @@
     fieldset do
       legend 'Addresses'
 
-      fields_for_collection :addresses do |i|
+      fields_for_collection :addresses do |i, address|
         div class: 'form-group' do
+          text "Address id: #{address.id}"
+
           label :street
           input_text :street, class: 'form-control', placeholder: 'Street', 'data-funky': "index-#{i}"
         end


### PR DESCRIPTION
Fixes #121 

This is just a first pass at implementing this. Any feedback is welcome.

One problem I faced was that `fields_for_collection` actually already passes an argument to the block: The index of the element in the collection. In order to not break the existing API I added the new `value` block parameter at second place.