### PR TITLE
Fix form_for signature according to original intent, API docs, and guides

### DIFF
--- a/lib/hanami/helpers/form_helper.rb
+++ b/lib/hanami/helpers/form_helper.rb
@@ -229,7 +229,7 @@ module Hanami
       #   @option options [Hash] :values An optional payload of objects to pass
       #   @param blk [Proc] A block that describes the contents of the form
       #
-      # @overload form_for(form, attributes, &blk)
+      # @overload form_for(form, attributes = {}, &blk)
       #   Use Form
       #   @param form [Hanami::Helpers::FormHelper::Form] a form object
       #   @param attributes [Hash] HTML attributes to pass to the form tag and form values
@@ -406,9 +406,9 @@ module Hanami
       #
       #     <button type="submit">Create</button>
       #   </form>
-      def form_for(name, url, options = {}, &blk)
+      def form_for(name, url = nil, options = {}, &blk)
         form = if name.is_a?(Form)
-                 options = url
+                 options = url || {}
                  name
                else
                  Form.new(name, url, options.delete(:values))

--- a/spec/integration/form_helper_spec.rb
+++ b/spec/integration/form_helper_spec.rb
@@ -15,6 +15,18 @@ RSpec.describe 'Form helper' do
     end
   end
 
+  describe 'form with Form object' do
+    before do
+      @params  = Hanami::Action::BaseParams.new({})
+      @session = Session.new(_csrf_token: 'ln16')
+      @actual  = FullStack::Views::Settings::Edit.render(format: :html, params: @params, session: @session)
+    end
+
+    it 'renders the form' do
+      expect(@actual).to include(%(<form action="/settings" method="POST" accept-charset="utf-8" id="settings-form">\n<input type="hidden" name="_csrf_token" value="#{@session[:_csrf_token]}">\n<div>\n<label for="settings-email">Email</label>\n<input type="email" name="settings[email]" id="settings-email" value="">\n</div>\n<button type="submit">Update settings</button>\n</form>))
+    end
+  end
+
   describe 'form to create a new resource' do
     describe 'first page load' do
       before do

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -446,6 +446,10 @@ module FullStack
       _escape '/sessions'
     end
 
+    def settings_path
+      _escape '/settings'
+    end
+
     def deliveries_path
       _escape '/deliveries'
     end
@@ -486,6 +490,17 @@ module FullStack
       class New
         include TestView
         template 'sessions/new'
+      end
+    end
+
+    module Settings
+      class Edit
+        include TestView
+        template 'settings/edit'
+
+        def form
+          Form.new(:settings, routes.settings_path)
+        end
       end
     end
 

--- a/spec/support/fixtures/templates/settings/edit.html.erb
+++ b/spec/support/fixtures/templates/settings/edit.html.erb
@@ -1,0 +1,10 @@
+<%=
+  form_for form do
+    div do
+      label :email
+      email_field :email
+    end
+
+    submit "Update settings"
+  end
+%>


### PR DESCRIPTION
Fixes #134 

---

Note: the problem wasn't caught until now because the other fixtures are always using more than one argument for `form_for`.

```erb
<%=
  form_for(form, class: "form-horizontal") do
    # ...
  end
%>
```

To test properly this signature, I added `spec/support/fixtures/templates/settings/edit.html.erb`, which only uses `form_for(form)` (one argument).