### PR TITLE
FormBuilder: fixing method _select_option_selected?

### DIFF
--- a/lib/hanami/helpers/form_helper/form_builder.rb
+++ b/lib/hanami/helpers/form_helper/form_builder.rb
@@ -1676,7 +1676,7 @@ module Hanami
         # @api private
         def _select_option_selected?(value, selected, input_value, multiple)
           if input_value && selected.nil?
-            value.to_s == input_value
+            value.to_s == input_value.to_s
           else
             (value == selected) ||
               _is_in_selected_values?(multiple, selected, value) ||

--- a/spec/unit/hanami/helpers/form_helper_spec.rb
+++ b/spec/unit/hanami/helpers/form_helper_spec.rb
@@ -2629,6 +2629,20 @@ RSpec.describe Hanami::Helpers::FormHelper do
           expect(actual).to include(%(<form action="/books" method="POST" accept-charset="utf-8" id="book-form">\n<select name="book[category]" id="book-category">\n<option value="">N&#x2F;A</option>\n<option value="horror" selected="selected">Horror</option>\n<option value="scify">SciFy</option>\n</select>\n</form>))
         end
       end
+
+      describe 'with non String values' do
+        let(:values)        { Hash[book: Book.new(category: val)] }
+        let(:option_values) { Hash['Horror' => "1", 'SciFy' => "2"] }
+        let(:val)           { 1 }
+
+        it 'sets correct value as selected' do
+          actual = view.form_for(:book, action, values: values) do
+            select :category, option_values
+          end.to_s
+
+          expect(actual).to include(%(<form action="/books" method="POST" accept-charset="utf-8" id="book-form">\n<select name="book[category]" id="book-category">\n<option value="1" selected="selected">Horror</option>\n<option value="2">SciFy</option>\n</select>\n</form>))
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Bug introduced in Hanami 1.2 PR #132

This avoids select element not having a selected option when comparing 5 (String) to 5 (Integer), for example.