### PR TITLE
Change CSRF meta tag from 'value' to 'content'

### DIFF
--- a/lib/hanami/helpers/form_helper.rb
+++ b/lib/hanami/helpers/form_helper.rb
@@ -457,16 +457,16 @@ module Hanami
       #   <html>
       #     <head>
       #       <!-- ... -->
-      #       <meta name="csrf-param" value="_csrf_token">
-      #       <meta name="csrf-token" value="4a038be85b7603c406dcbfad4b9cdf91ec6ca138ed6441163a07bb0fdfbe25b5">
+      #       <meta name="csrf-param" content="_csrf_token">
+      #       <meta name="csrf-token" content="4a038be85b7603c406dcbfad4b9cdf91ec6ca138ed6441163a07bb0fdfbe25b5">
       #     </head>
       #     <!-- ... -->
       #   </html>
       def csrf_meta_tags
         return if csrf_token.nil?
 
-        html.meta(name: "csrf-param", value: CSRF_TOKEN) +
-          html.meta(name: "csrf-token", value: csrf_token)
+        html.meta(name: "csrf-param", content: CSRF_TOKEN) +
+          html.meta(name: "csrf-token", content: csrf_token)
       end
     end
   end

--- a/spec/unit/hanami/helpers/form_helper_spec.rb
+++ b/spec/unit/hanami/helpers/form_helper_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe Hanami::Helpers::FormHelper do
       let(:csrf_token) { 'abc123' }
 
       it "prints meta tags" do
-        expected = %(<meta name="csrf-param" value="_csrf_token">\n<meta name="csrf-token" value="#{csrf_token}">)
+        expected = %(<meta name="csrf-param" content="_csrf_token">\n<meta name="csrf-token" content="#{csrf_token}">)
         expect(view.csrf_meta_tags.to_s).to eq(expected)
       end
 


### PR DESCRIPTION
`value` isn't a valid attribute for a meta tag, according to [the spec](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta), we want `content` instead.


Discovered this because I was trying to use `hanami-ujs` and it wasn't picking the CSRF meta tag values properly, since it looks for the `content` attribute. I'm using this branc now and it solved the problem. :)

Fixes bug introduced in: #129 

(Intentionally opened against `master` instead of `develop` since this PR is fixing a bug, which can be a patch release.)
