### PR TITLE
Adds a disabled attribute to the select option prompt

### DIFF
--- a/lib/hanami/helpers/form_helper/form_builder.rb
+++ b/lib/hanami/helpers/form_helper/form_builder.rb
@@ -1224,7 +1224,7 @@ module Hanami
         #
         #   <!-- output -->
         #   <select name="book[store]" id="book-store" class="form-control">
-        #     <option>Select a store</option>
+        #     <option disabled="disabled">Select a store</option>
         #     <option value="it">Italy</option>
         #     <option value="us">United States</option>
         #   </select>
@@ -1287,7 +1287,7 @@ module Hanami
           input_value = _value(name)
 
           super(attributes) do
-            option(prompt) unless prompt.nil?
+            option(prompt, disabled: true) if prompt
 
             already_selected = nil
             values.each do |content, value|

--- a/spec/unit/hanami/helpers/form_helper_spec.rb
+++ b/spec/unit/hanami/helpers/form_helper_spec.rb
@@ -2514,7 +2514,7 @@ RSpec.describe Hanami::Helpers::FormHelper do
           select :store, option_values, options: { prompt: 'Select a store' }
         end.to_s
 
-        expect(actual).to include(%(<select name="book[store]" id="book-store">\n<option>Select a store</option>\n<option value="it">Italy</option>\n<option value="us">United States</option>\n</select>))
+        expect(actual).to include(%(<select name="book[store]" id="book-store">\n<option disabled="disabled">Select a store</option>\n<option value="it">Italy</option>\n<option value="us">United States</option>\n</select>))
       end
 
       it 'allows blank string' do
@@ -2522,7 +2522,7 @@ RSpec.describe Hanami::Helpers::FormHelper do
           select :store, option_values, options: { prompt: '' }
         end.to_s
 
-        expect(actual).to include(%(<select name="book[store]" id="book-store">\n<option></option>\n<option value="it">Italy</option>\n<option value="us">United States</option>\n</select>))
+        expect(actual).to include(%(<select name="book[store]" id="book-store">\n<option disabled="disabled"></option>\n<option value="it">Italy</option>\n<option value="us">United States</option>\n</select>))
       end
 
       describe 'with values' do
@@ -2534,7 +2534,7 @@ RSpec.describe Hanami::Helpers::FormHelper do
             select :store, option_values, options: { prompt: 'Select a store' }
           end.to_s
 
-          expect(actual).to include(%(<select name="book[store]" id="book-store">\n<option>Select a store</option>\n<option value="it" selected="selected">Italy</option>\n<option value="us">United States</option>\n</select>))
+          expect(actual).to include(%(<select name="book[store]" id="book-store">\n<option disabled="disabled">Select a store</option>\n<option value="it" selected="selected">Italy</option>\n<option value="us">United States</option>\n</select>))
         end
       end
 
@@ -2548,7 +2548,7 @@ RSpec.describe Hanami::Helpers::FormHelper do
               select :store, option_values, options: { prompt: 'Select a store' }
             end.to_s
 
-            expect(actual).to include(%(<select name="book[store]" id="book-store">\n<option>Select a store</option>\n<option value="it" selected="selected">Italy</option>\n<option value="us">United States</option>\n</select>))
+            expect(actual).to include(%(<select name="book[store]" id="book-store">\n<option disabled="disabled">Select a store</option>\n<option value="it" selected="selected">Italy</option>\n<option value="us">United States</option>\n</select>))
           end
         end
 


### PR DESCRIPTION
Without this attribute Hanami will treat "Select store...", for example, as the value and add it to the params.