### PR TITLE
`#form_for` allow to pass params inline

### DIFF
--- a/lib/hanami/helpers/form_helper.rb
+++ b/lib/hanami/helpers/form_helper.rb
@@ -230,6 +230,7 @@ module Hanami
       #   @param url [String] the form action URL
       #   @param options [Hash] HTML attributes to pass to the form tag and form values
       #   @option options [Hash] :values An optional payload of objects to pass
+      #   @option options [Hash] :params An optional override of params
       #   @param blk [Proc] A block that describes the contents of the form
       #
       # @overload form_for(form, attributes = {}, &blk)
@@ -406,6 +407,24 @@ module Hanami
       #     <input type="hidden" name="_csrf_token" value="920cd5bfaecc6e58368950e790f2f7b4e5561eeeab230aa1b7de1b1f40ea7d5d">
       #     <input type="text" name="delivery[customer_name]" id="delivery-customer-name" value="">
       #     <input type="text" name="delivery[address][city]" id="delivery-address-city" value="">
+      #
+      #     <button type="submit">Create</button>
+      #   </form>
+      #
+      # @example Override params
+      #   <%=
+      #     form_for :song, routes.songs_path, params: { song: { title: "Envision" } } do
+      #       text_field :title
+      #
+      #       submit 'Create'
+      #     end
+      #   %>
+      #
+      #   <!-- output -->
+      #
+      #   <form action="/songs" accept-charset="utf-8" id="song-form" method="POST">
+      #     <input type="hidden" name="_csrf_token" value="920cd5bfaecc6e58368950e790f2f7b4e5561eeeab230aa1b7de1b1f40ea7d5d">
+      #     <input type="text" name="song[title]" id="song-title" value="Envision">
       #
       #     <button type="submit">Create</button>
       #   </form>

--- a/lib/hanami/helpers/form_helper.rb
+++ b/lib/hanami/helpers/form_helper.rb
@@ -409,7 +409,7 @@ module Hanami
       #
       #     <button type="submit">Create</button>
       #   </form>
-      def form_for(name, url = nil, options = {}, &blk)
+      def form_for(name, url = nil, options = {}, &blk) # rubocop:disable Metrics/MethodLength
         form = if name.is_a?(Form)
                  options = url || {}
                  name
@@ -417,11 +417,12 @@ module Hanami
                  Form.new(name, url, options.delete(:values))
                end
 
+        params = options.delete(:params)
         opts = options.dup
         opts[:"data-remote"] = opts.delete(:remote) if opts.key?(:remote)
         attributes = { action: form.url, method: form.verb, 'accept-charset': DEFAULT_CHARSET, id: "#{form.name}-form" }.merge(opts)
 
-        FormBuilder.new(form, attributes, self, &blk)
+        FormBuilder.new(form, attributes, self, params, &blk)
       end
 
       # Returns CSRF Protection Token stored in session.

--- a/lib/hanami/helpers/form_helper/form_builder.rb
+++ b/lib/hanami/helpers/form_helper/form_builder.rb
@@ -81,11 +81,12 @@ module Hanami
 
         # Instantiate a form builder
         #
-        # @overload initialize(form, attributes, context, &blk)
+        # @overload initialize(form, attributes, context, params, &blk)
         #   Top level form
         #   @param form [Hanami::Helpers:FormHelper::Form] the form
         #   @param attributes [::Hash] a set of HTML attributes
         #   @param context [Hanami::Helpers::FormHelper]
+        #   @param params [Hash] optional set of params to override the ones that are coming from the view context
         #   @param blk [Proc] a block that describes the contents of the form
         #
         # @overload initialize(form, attributes, params, &blk)

--- a/lib/hanami/helpers/form_helper/form_builder.rb
+++ b/lib/hanami/helpers/form_helper/form_builder.rb
@@ -99,7 +99,7 @@ module Hanami
         #
         # @since 0.2.0
         # @api private
-        def initialize(form, attributes, context = nil, &blk) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+        def initialize(form, attributes, context = nil, params = nil, &blk) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
           super()
 
           @context    = context
@@ -115,7 +115,7 @@ module Hanami
           else
             @form        = form
             @name        = form.name
-            @values      = Values.new(form.values, @context.params)
+            @values      = Values.new(form.values, params || @context.params)
             @attributes  = attributes
             @verb_method = verb_method
             @csrf_token  = csrf_token

--- a/spec/unit/hanami/helpers/form_helper_spec.rb
+++ b/spec/unit/hanami/helpers/form_helper_spec.rb
@@ -127,6 +127,21 @@ RSpec.describe Hanami::Helpers::FormHelper do
         expect(actual.to_s).to eq(%(<form action="/books" method="POST" accept-charset="utf-8" id="book-form" data-remote="">\n\n</form>))
       end
     end
+
+    context "inline params" do
+      let(:view)   { FormHelperView.new(params) }
+      let(:params) { { song: { title: "Orphans" } } }
+      let(:inline_params) { { song: { title: "Arabesque" } } }
+      let(:action) { '/songs' }
+
+      it "renders" do
+        actual = view.form_for(:song, action, params: inline_params) do
+          text_field :title
+        end.to_s
+
+        expect(actual).to eq(%(<form action="/songs" method="POST" accept-charset="utf-8" id="song-form">\n<input type="text" name="song[title]" id="song-title" value="#{inline_params.dig(:song, :title)}">\n</form>))
+      end
+    end
   end
 
   #


### PR DESCRIPTION
Make possible for `#form_for` to accept `params:` a keyword argument to override params coming from the view context.

This enhancement provides the ultimate flexibility for people who want to take control on form rendering.

---

Closes https://github.com/hanami/helpers/issues/149